### PR TITLE
Hidden Nodes Feature to Reclass.NET

### DIFF
--- a/ReClass.NET/DataExchange/ReClass/ReClassFile.cs
+++ b/ReClass.NET/DataExchange/ReClass/ReClassFile.cs
@@ -165,9 +165,10 @@ namespace ReClassNET.DataExchange.ReClass
 
 				node.Name = element.Attribute("Name")?.Value ?? string.Empty;
 				node.Comment = element.Attribute("Comment")?.Value ?? string.Empty;
+                node.IsHidden = element.Attribute("bHidden")?.Value.Equals("1") ?? false;         
 
-				// Convert the Custom node into normal hex nodes.
-				if (node is CustomNode)
+                // Convert the Custom node into normal hex nodes.
+                if (node is CustomNode)
 				{
 					int.TryParse(element.Attribute("Size")?.Value, out var size);
 
@@ -243,7 +244,8 @@ namespace ReClassNET.DataExchange.ReClass
 							.Select(e => new VMethodNode
 							{
 								Name = e.Attribute("Name")?.Value ?? string.Empty,
-								Comment = e.Attribute("Comment")?.Value ?? string.Empty
+								Comment = e.Attribute("Comment")?.Value ?? string.Empty,
+                                IsHidden = e.Attribute("bHidden")?.Value.Equals("1") ?? false
 							})
 							.ForEach(vtableNode.AddNode);
 						break;

--- a/ReClass.NET/DataExchange/ReClass/ReClassNetFile.Constants.cs
+++ b/ReClass.NET/DataExchange/ReClass/ReClassNetFile.Constants.cs
@@ -23,7 +23,8 @@
 		public const string XmlUuidAttribute = "uuid";
 		public const string XmlNameAttribute = "name";
 		public const string XmlCommentAttribute = "comment";
-		public const string XmlAddressAttribute = "address";
+        public const string XmlHiddenAttribute = "hidden";
+        public const string XmlAddressAttribute = "address";
 		public const string XmlTypeAttribute = "type";
 		public const string XmlReferenceAttribute = "reference";
 		public const string XmlCountAttribute = "count";

--- a/ReClass.NET/DataExchange/ReClass/ReClassNetFile.Read.cs
+++ b/ReClass.NET/DataExchange/ReClass/ReClassNetFile.Read.cs
@@ -132,6 +132,7 @@ namespace ReClassNET.DataExchange.ReClass
 
 				node.Name = element.Attribute(XmlNameAttribute)?.Value ?? string.Empty;
 				node.Comment = element.Attribute(XmlCommentAttribute)?.Value ?? string.Empty;
+                node.IsHidden = element.Attribute(XmlHiddenAttribute)?.Value.Equals("True") ?? false;
 
 				if (node is BaseReferenceNode referenceNode)
 				{
@@ -164,7 +165,8 @@ namespace ReClassNET.DataExchange.ReClass
 							.Select(e => new VMethodNode
 							{
 								Name = e.Attribute(XmlNameAttribute)?.Value ?? string.Empty,
-								Comment = e.Attribute(XmlCommentAttribute)?.Value ?? string.Empty
+								Comment = e.Attribute(XmlCommentAttribute)?.Value ?? string.Empty,
+                                IsHidden = e.Attribute(XmlHiddenAttribute)?.Value.Equals("True") ?? false
 							})
 							.ForEach(vtableNode.AddNode);
 						break;

--- a/ReClass.NET/DataExchange/ReClass/ReClassNetFile.Write.cs
+++ b/ReClass.NET/DataExchange/ReClass/ReClassNetFile.Write.cs
@@ -89,6 +89,7 @@ namespace ReClassNET.DataExchange.ReClass
 					XmlNodeElement,
 					new XAttribute(XmlNameAttribute, node.Name ?? string.Empty),
 					new XAttribute(XmlCommentAttribute, node.Comment ?? string.Empty),
+                    new XAttribute(XmlHiddenAttribute, node.IsHidden.ToString()),
 					new XAttribute(XmlTypeAttribute, typeString)
 				);
 
@@ -104,7 +105,8 @@ namespace ReClassNET.DataExchange.ReClass
 						element.Add(vtableNode.Nodes.Select(n => new XElement(
 							XmlMethodElement,
 							new XAttribute(XmlNameAttribute, n.Name ?? string.Empty),
-							new XAttribute(XmlCommentAttribute, n.Comment ?? string.Empty)
+							new XAttribute(XmlCommentAttribute, n.Comment ?? string.Empty),
+                            new XAttribute(XmlHiddenAttribute, n.IsHidden.ToString())
 						)));
 						break;
 					}

--- a/ReClass.NET/Nodes/BaseNode.cs
+++ b/ReClass.NET/Nodes/BaseNode.cs
@@ -21,7 +21,7 @@ namespace ReClassNET.Nodes
 		internal static readonly List<INodeInfoReader> NodeInfoReader = new List<INodeInfoReader>();
 
 		protected static readonly int TextPadding = Icons.Dimensions;
-		protected static readonly int HiddenHeight = 1;
+		protected static readonly int HiddenHeight = 0;
 
 		private static int nodeIndex = 0;
 
@@ -41,7 +41,7 @@ namespace ReClassNET.Nodes
 		public BaseContainerNode ParentNode { get; internal set; }
 
 		/// <summary>Gets or sets a value indicating whether this object is hidden.</summary>
-		public bool IsHidden { get; protected set; }
+		public bool IsHidden { get; set; }
 
 		/// <summary>Gets or sets a value indicating whether this object is selected.</summary>
 		public bool IsSelected { get; set; }

--- a/ReClass.NET/UI/MemoryViewControl.Designer.cs
+++ b/ReClass.NET/UI/MemoryViewControl.Designer.cs
@@ -101,6 +101,10 @@
 			this.toolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
 			this.copyNodeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.pasteNodesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.hideNodesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.unhideChildNodesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.unhideNodesBelowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.unhideNodesAboveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.removeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
 			this.copyAddressToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -131,6 +135,10 @@
             this.toolStripSeparator14,
             this.copyNodeToolStripMenuItem,
             this.pasteNodesToolStripMenuItem,
+            this.hideNodesToolStripMenuItem,
+            this.unhideChildNodesToolStripMenuItem,
+            this.unhideNodesBelowToolStripMenuItem,
+            this.unhideNodesAboveToolStripMenuItem,
             this.removeToolStripMenuItem,
             this.toolStripSeparator12,
             this.copyAddressToolStripMenuItem,
@@ -769,7 +777,39 @@
 			this.pasteNodesToolStripMenuItem.Size = new System.Drawing.Size(269, 22);
 			this.pasteNodesToolStripMenuItem.Text = "Paste Node(s)";
 			this.pasteNodesToolStripMenuItem.Click += new System.EventHandler(this.pasteNodesToolStripMenuItem_Click);
-			// 
+            // 
+            // hideNodesToolStripMenuItem
+            // 
+            this.hideNodesToolStripMenuItem.Image = global::ReClassNET.Properties.Resources.B16x16_Eye;
+            this.hideNodesToolStripMenuItem.Name = "hideNodesToolStripMenuItem";
+            this.hideNodesToolStripMenuItem.Size = new System.Drawing.Size(269, 22);
+            this.hideNodesToolStripMenuItem.Text = "Hide selected Node(s)";
+            this.hideNodesToolStripMenuItem.Click += new System.EventHandler(this.hideNodesToolStripMenuItem_Click);
+            // 
+            // unhideChildNodesToolStripMenuItem
+            // 
+            this.unhideChildNodesToolStripMenuItem.Image = global::ReClassNET.Properties.Resources.B16x16_Eye;
+            this.unhideChildNodesToolStripMenuItem.Name = "unhideChildNodesToolStripMenuItem";
+            this.unhideChildNodesToolStripMenuItem.Size = new System.Drawing.Size(269, 22);
+            this.unhideChildNodesToolStripMenuItem.Text = "Unhide child Node(s)";
+            this.unhideChildNodesToolStripMenuItem.Click += new System.EventHandler(this.unhideChildNodesToolStripMenuItem_Click);
+            // 
+            // unhideNodesBelowToolStripMenuItem
+            // 
+            this.unhideNodesBelowToolStripMenuItem.Image = global::ReClassNET.Properties.Resources.B16x16_Eye;
+            this.unhideNodesBelowToolStripMenuItem.Name = "unhideNodesBelowToolStripMenuItem";
+            this.unhideNodesBelowToolStripMenuItem.Size = new System.Drawing.Size(269, 22);
+            this.unhideNodesBelowToolStripMenuItem.Text = "Unhide Node(s) below";
+            this.unhideNodesBelowToolStripMenuItem.Click += new System.EventHandler(this.unhideNodesBelowToolStripMenuItem_Click);
+            // 
+            // unhideNodesAboveToolStripMenuItem
+            // 
+            this.unhideNodesAboveToolStripMenuItem.Image = global::ReClassNET.Properties.Resources.B16x16_Eye;
+            this.unhideNodesAboveToolStripMenuItem.Name = "unhideNodesAboveToolStripMenuItem";
+            this.unhideNodesAboveToolStripMenuItem.Size = new System.Drawing.Size(269, 22);
+            this.unhideNodesAboveToolStripMenuItem.Text = "Unhide Node(s) above";
+            this.unhideNodesAboveToolStripMenuItem.Click += new System.EventHandler(this.unhideNodesAboveToolStripMenuItem_Click);
+            // 
 			// removeToolStripMenuItem
 			// 
 			this.removeToolStripMenuItem.Image = global::ReClassNET.Properties.Resources.B16x16_Button_Delete;
@@ -914,6 +954,10 @@
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
 		private System.Windows.Forms.ToolStripMenuItem copyNodeToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem pasteNodesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem hideNodesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem unhideChildNodesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem unhideNodesBelowToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem unhideNodesAboveToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator12;
 		private System.Windows.Forms.ToolStripMenuItem dissectNodesToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;

--- a/ReClass.NET/UI/MemoryViewControl.cs
+++ b/ReClass.NET/UI/MemoryViewControl.cs
@@ -316,6 +316,7 @@ namespace ReClassNET.UI
 											continue;
 										}
 
+                                        if (hotSpot.Node is BaseContainerNode) continue;
 										var first = Utils.Min(selectedNodes[0], hotSpot, h => h.Node.Offset.ToInt32());
 										var last = first == hotSpot ? selectedNodes[0] : hotSpot;
 
@@ -777,6 +778,39 @@ namespace ReClassNET.UI
 					break;
 			}
 
+            var hiddenNodesExistBelow = false;
+            var hiddenNodesExistAbove = false;
+            if (count == 1)
+            {
+                var selNode = SelectedNodes.ElementAt(0);
+                var parNode = SelectedNodes.ElementAt(0).ParentNode;
+                if (parNode != null)
+                {
+                    var selNodeIndex = parNode.FindNodeIndex(selNode);
+                    if ((selNodeIndex+1 < parNode.Nodes.Count()) && (parNode.Nodes.ElementAt(selNodeIndex + 1).IsHidden == true))
+                    {
+                        hiddenNodesExistBelow = true;
+                    }
+                    if ((selNodeIndex - 1 > -1) && (parNode.Nodes.ElementAt(selNodeIndex - 1).IsHidden == true))
+                    {
+                        hiddenNodesExistAbove = true;
+                    }
+                }
+            }
+
+            unhideNodesBelowToolStripMenuItem.Enabled = hiddenNodesExistBelow;
+            unhideNodesAboveToolStripMenuItem.Enabled = hiddenNodesExistAbove;
+
+
+            var areNodesHideable = true;
+            foreach (BaseNode bs in SelectedNodes) areNodesHideable = areNodesHideable & !(bs is ClassNode);
+            hideNodesToolStripMenuItem.Enabled = areNodesHideable;
+
+            var parentNodeTypeSelected = false;
+            if ((count == 1) && (SelectedNodes.ElementAt(0) is BaseContainerNode)) parentNodeTypeSelected = true;
+            unhideChildNodesToolStripMenuItem.Enabled = parentNodeTypeSelected;
+
+
 			addBytesToolStripMenuItem.Enabled = node?.ParentNode != null || nodeIsClass;
 			insertBytesToolStripMenuItem.Enabled = count == 1 && node?.ParentNode != null;
 
@@ -939,6 +973,26 @@ namespace ReClassNET.UI
 		{
 			PasteNodeFromClipboardToSelection();
 		}
+
+        private void hideNodesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            HideSelectedNodes();
+        }
+
+        private void unhideNodesBelowToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            UnhideNodesBelow();
+        }
+		
+        private void unhideNodesAboveToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            UnhideNodesAbove();
+        }
+
+        private void unhideChildNodesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            UnhideChildNodes();
+        }
 
 		private void removeToolStripMenuItem_Click(object sender, EventArgs e)
 		{
@@ -1161,6 +1215,97 @@ namespace ReClassNET.UI
 
 			Invalidate();
 		}
+
+        private void HideSelectedNodes()
+        {
+            foreach (HotSpot hs in selectedNodes) hs.Node.IsHidden = true;
+
+            selectedNodes.Clear();
+
+            OnSelectionChanged();
+
+            Invalidate();
+        }
+
+        private void UnhideChildNodes()
+        {
+            BaseContainerNode bcn = (BaseContainerNode) selectedNodes[0].Node;
+            foreach (BaseNode bn in bcn.Nodes)
+            {
+                bn.IsHidden = false;
+                bn.IsSelected = false;
+            }
+
+            selectedNodes[0].Node.IsSelected = false;
+
+            selectedNodes.Clear();
+
+            OnSelectionChanged();
+
+            Invalidate();
+        }
+
+        private void UnhideNodesBelow()
+        {
+            var selNode = selectedNodes[0].Node;
+            var parNode = selNode.ParentNode;
+
+            if (parNode == null) return;
+
+            var hiddenNodeStartIndex = parNode.FindNodeIndex(selNode) + 1;
+
+            if (hiddenNodeStartIndex >= parNode.Nodes.Count()) return;
+
+            for (int i = hiddenNodeStartIndex; i < parNode.Nodes.Count(); i++)
+            {
+                var indexNode = parNode.Nodes.ElementAt(i);
+                if (indexNode.IsHidden)
+                {
+                    indexNode.IsHidden = false;
+                    indexNode.IsSelected = false;
+                }
+                else break;
+            }
+
+            selNode.IsSelected = false;
+
+            selectedNodes.Clear();
+
+            OnSelectionChanged();
+
+            Invalidate();
+        }
+
+        private void UnhideNodesAbove()
+        {
+            var selNode = selectedNodes[0].Node;
+            var parNode = selNode.ParentNode;
+
+            if (parNode == null) return;
+
+            var hiddenNodeStartIndex = parNode.FindNodeIndex(selNode) - 1;
+
+            if (hiddenNodeStartIndex < 0) return;
+
+            for (int i = hiddenNodeStartIndex; i > -1; i--)
+            {
+                var indexNode = parNode.Nodes.ElementAt(i);
+                if (indexNode.IsHidden)
+                {
+                    indexNode.IsHidden = false;
+                    indexNode.IsSelected = false;
+                }
+                else break;
+            }
+
+            selNode.IsSelected = false;
+
+            selectedNodes.Clear();
+
+            OnSelectionChanged();
+
+            Invalidate();
+        }
 
 		private void CopySelectedNodesToClipboard()
 		{

--- a/ReClass.NET/UI/MemoryViewControl.cs
+++ b/ReClass.NET/UI/MemoryViewControl.cs
@@ -807,8 +807,14 @@ namespace ReClassNET.UI
             hideNodesToolStripMenuItem.Enabled = areNodesHideable;
 
             var parentNodeTypeSelected = false;
-            if ((count == 1) && (SelectedNodes.ElementAt(0) is BaseContainerNode)) parentNodeTypeSelected = true;
-            unhideChildNodesToolStripMenuItem.Enabled = parentNodeTypeSelected;
+            var areChildNodesHidden = false;
+            if ((count == 1) && (SelectedNodes.ElementAt(0) is BaseContainerNode))
+            {
+                var selbcn = (BaseContainerNode)SelectedNodes.ElementAt(0);
+                parentNodeTypeSelected = true;
+                foreach (BaseNode bn in selbcn.Nodes) areChildNodesHidden = areChildNodesHidden | bn.IsHidden;
+            }
+            unhideChildNodesToolStripMenuItem.Enabled = parentNodeTypeSelected & areChildNodesHidden;
 
 
 			addBytesToolStripMenuItem.Enabled = node?.ParentNode != null || nodeIsClass;


### PR DESCRIPTION
Hey KN4CK3R,

One of the things i've always wanted in Reclass.NET was the ability to hide nodes for improved visibility and remove the noise on non-relevant padding. I decided to pull out visual studio this morning and just do it =P

Here are the Features in this pull request:

- "Hide selected Node(s)" context menu item
- "Unhide child Node(s)" context menu item
- "Unhide Node(s) below" context menu item
- "Unhide Node(s) above" context menu item
- Changes to *.reclass parser to understand/import legacy 'bHidden="1"' attributes
- Changes to *.rcnet parser to write/read hidden="true" attributes for the modern rcnet schema

I did a bunch of node validation to qualify whether to enable to disable the context menu items. I also wonder if these 4 context menu items should be placed into a submenu labeled "Node Visibility", not sure if that was cleaner and didn't want to explode the size of the main context menu. Feel free to edit all this at your leisure.

I did as much testing as I could, but perhaps may need a little more incase i introduced weird corner cases.

Here is a preview:

![image](https://user-images.githubusercontent.com/34756141/50301244-cc212900-0454-11e9-8fea-341a25cb6cc1.png)

