### PR TITLE
Fixed a bug with dependency sorting in code generation

### DIFF
--- a/ReClass.NET/CodeGenerator/CppCodeGenerator.cs
+++ b/ReClass.NET/CodeGenerator/CppCodeGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -142,7 +142,13 @@ namespace ReClassNET.CodeGenerator
 
 			foreach (var referenceNode in node.Nodes.OfType<BaseReferenceNode>())
 			{
-				foreach (var referencedNode in YieldReversedHierarchy(referenceNode.InnerNode, alreadySeen))
+                // Unnecessary. Class pointers are forward declared.
+                if (referenceNode is ClassPtrNode)
+                {
+                    continue;
+                }
+
+                foreach (var referencedNode in YieldReversedHierarchy(referenceNode.InnerNode, alreadySeen))
 				{
 					yield return referencedNode;
 				}


### PR DESCRIPTION
Fixed something that was really bothering me. In some circumstances the class ordering would not generate valid code for C++. You can see this in my [project's](https://github.com/praydog/RE2-Mod-Framework/tree/8a657d78a61787fdb5506988f61c938243568a8e/reversing) rcnet file.

Try generating code, and it will place the RETransform class before the REComponent class, which is supposed to inherit from REComponent. This lead to me having to manually move the class myself. I don't code in C# so hopefully this is correct.