### PR TITLE
Switched Enum value and name around when reading saved ones

### DIFF
--- a/ReClass.NET/Forms/EnumEditorForm.cs
+++ b/ReClass.NET/Forms/EnumEditorForm.cs
@@ -26,7 +26,7 @@ namespace ReClassNET.Forms
 
 			foreach (var kv in @enum.Values)
 			{
-				enumDataGridView.Rows.Add(kv.Key, kv.Value);
+				enumDataGridView.Rows.Add(kv.Value, kv.Key);
 			}
 		}
 


### PR DESCRIPTION
Currently they're switched around when reading them back in.

https://gfycat.com/bittercomposedchimpanzee

There's also an exception afterwards.

After switching them around, the columns are lined up properly and the exception is gone aswell.
https://gfycat.com/obesecheerfulbass

Additionally, if you delete an Enum it's still visible in the Main UI. Haven't looked too thoroughly through  the code yet, so this might be an easier fix for you.

Keep up the great work :) 👍 

EDIT: Renaming Enums also doesn't properly update in the UI.