### PR TITLE
Fixed 2 issues with enums 

### DIFF
--- a/ReClass.NET/Project/EnumDescription.cs
+++ b/ReClass.NET/Project/EnumDescription.cs
@@ -26,7 +26,7 @@ namespace ReClassNET.Project
 
 		public void SetData(bool useFlagsMode, UnderlyingTypeSize size, IEnumerable<KeyValuePair<string, long>> values)
 		{
-			var temp = values.OrderBy(t => t.Key).ToList();
+			var temp = values.OrderBy(t => t.Value).ToList();
 
 			if (useFlagsMode)
 			{


### PR DESCRIPTION
1. Enums in the flags mode are read incorrectly. Let's say a flags field occupies 32 bit and bit 31 is enabled. The current code would read this field as signed int32 and treat it as negative integer number because the leftmost bit is enabled. Then this int32 is converted to long and then to ulong. After that the final ulong value will have bits 32-61 enabled making it a bigger value then the original one. As a result, EnumNode.GetFlagsStringRepresentation() incorrectly processes the final value and always displays a negative number instead of a string with list of enabled flags.

2. Rows in the Enums editor are ordered by Name column and not the Value.