### PR TITLE
Add some checks that should fix some issues with certain packers

### DIFF
--- a/NativeCore/Windows/EnumerateRemoteSectionsAndModules.cpp
+++ b/NativeCore/Windows/EnumerateRemoteSectionsAndModules.cpp
@@ -96,22 +96,27 @@ void RC_CallConv EnumerateRemoteSectionsAndModules(RC_Pointer process, Enumerate
 						const auto sectionAddress = reinterpret_cast<size_t>(me32.modBaseAddr) + sectionHeader.VirtualAddress;
 						for (auto j = it; j != std::end(sections); ++j)
 						{
-							if (sectionAddress >= reinterpret_cast<size_t>(j->BaseAddress) && sectionAddress < reinterpret_cast<size_t>(j->BaseAddress) + static_cast<size_t>(j->Size))
+							if (sectionAddress >= reinterpret_cast<size_t>(j->BaseAddress) 
+								&& sectionAddress < reinterpret_cast<size_t>(j->BaseAddress) + static_cast<size_t>(j->Size)
+								&& sectionHeader.VirtualAddress + sectionHeader.Misc.VirtualSize <= me32.modBaseSize )
 							{
-								// Copy the name because it is not null padded.
-								char buffer[IMAGE_SIZEOF_SHORT_NAME + 1] = { 0 };
-								std::memcpy(buffer, sectionHeader.Name, IMAGE_SIZEOF_SHORT_NAME);
-
-								if (std::strcmp(buffer, ".text") == 0 || std::strcmp(buffer, "code") == 0)
+								if ((sectionHeader.Characteristics & IMAGE_SCN_CNT_CODE) == IMAGE_SCN_CNT_CODE)
 								{
 									j->Category = SectionCategory::CODE;
 								}
-								else if (std::strcmp(buffer, ".data") == 0 || std::strcmp(buffer, "data") == 0 || std::strcmp(buffer, ".rdata") == 0 || std::strcmp(buffer, ".idata") == 0)
+								else if (sectionHeader.Characteristics & (IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_CNT_UNINITIALIZED_DATA))
 								{
 									j->Category = SectionCategory::DATA;
 								}
 
-								MultiByteToUnicode(buffer, j->Name, IMAGE_SIZEOF_SHORT_NAME);
+								try {
+									// Copy the name because it is not null padded.
+									char buffer[IMAGE_SIZEOF_SHORT_NAME + 1] = { 0 };
+									std::memcpy(buffer, sectionHeader.Name, IMAGE_SIZEOF_SHORT_NAME);
+									MultiByteToUnicode(buffer, j->Name, IMAGE_SIZEOF_SHORT_NAME);
+								} catch (std::range_error &) {
+									std::memset(j->Name, 0, sizeof j->Name);
+								}
 								std::memcpy(j->ModulePath, me32.szExePath, std::min(MAX_PATH, PATH_MAXIMUM_LENGTH));
 
 								break;


### PR DESCRIPTION
I was running into some issues using ReClass.NET with on a program protected by Themida, so I fixed them.

- At some point, Themida intentionally fills the first 24 bytes of the `.idata` header with garbage (Name, VirtualSize, VirtualAddress, SizeOfRawData all get clobbered), so I added a check to make sure VA+VirtualSize doesn't exceed the size of the current module.
- I made it so the category is detected by using the descriptive flags set in the `Characteristics` field, instead of the section name. This should be more accurate.
- Additionally, I wrapped the char-to-char16_t conversion in a `try-catch` block, so even if it fails from malformed character data, it won't just crash. 
