### PR TITLE
Edit node name (if any) when F2 is pressed

### DIFF
--- a/ReClass.NET/Forms/MainForm.Functions.cs
+++ b/ReClass.NET/Forms/MainForm.Functions.cs
@@ -410,6 +410,17 @@ namespace ReClassNET.Forms
 			}
 		}
 
+		private void EditSelectedNodeName()
+		{
+			var selected = memoryViewControl.GetSelectedNodes();
+			var selectedNode = selected.FirstOrDefault();
+
+			if (selected.Count == 1)
+			{
+				memoryViewControl.ShowEditBoxForName(selectedNode);
+			}
+		}
+
 		private void RemoveSelectedNodes()
 		{
 			memoryViewControl.GetSelectedNodes()

--- a/ReClass.NET/Forms/MainForm.cs
+++ b/ReClass.NET/Forms/MainForm.cs
@@ -766,22 +766,24 @@ namespace ReClassNET.Forms
 			CurrentClassNode = node;
 		}
 
-		private void memoryViewControl_KeyDown(object sender, KeyEventArgs e)
+		private void memoryViewControl_KeyDown(object sender, KeyEventArgs args)
 		{
-			if (e.Control)
+			switch (args.KeyCode)
 			{
-				if (e.KeyCode == Keys.C)
-				{
+				case Keys.C when args.Control:
 					CopySelectedNodesToClipboard();
-				}
-				else if (e.KeyCode == Keys.V)
-				{
+					break;
+				case Keys.V when args.Control:
 					PasteNodeFromClipboardToSelection();
-				}
-			}
-			else if (e.KeyCode == Keys.Delete)
-			{
-				RemoveSelectedNodes();
+					break;
+
+				case Keys.Delete:
+					RemoveSelectedNodes();
+					break;
+
+				case Keys.F2:
+					EditSelectedNodeName();
+					break;
 			}
 		}
 

--- a/ReClass.NET/UI/HotSpotTextBox.cs
+++ b/ReClass.NET/UI/HotSpotTextBox.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Windows.Forms;
 

--- a/ReClass.NET/UI/MemoryViewControl.Designer.cs
+++ b/ReClass.NET/UI/MemoryViewControl.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace ReClassNET.UI
+namespace ReClassNET.UI
 {
 	partial class MemoryViewControl
 	{

--- a/ReClass.NET/UI/MemoryViewControl.cs
+++ b/ReClass.NET/UI/MemoryViewControl.cs
@@ -381,6 +381,20 @@ namespace ReClassNET.UI
 			base.OnMouseDoubleClick(e);
 		}
 
+		public void ShowEditBoxForName(SelectedNodeInfo selection)
+		{
+			var hotSpot = hotSpots.FirstOrDefault(spot => spot.Address == selection.Address &&
+			                                                      spot.Type == HotSpotType.Edit &&
+			                                                      spot.Text == selection.Node.Name);
+			if (hotSpot != null)
+			{
+				editBox.BackColor = Program.Settings.SelectedColor;
+				editBox.HotSpot = hotSpot;
+				editBox.Visible = true;
+				editBox.ReadOnly = false;
+			}
+		}
+
 		private Point toolTipPosition;
 		protected override void OnMouseHover(EventArgs e)
 		{

--- a/ReClass.NET/UI/MemoryViewControl.cs
+++ b/ReClass.NET/UI/MemoryViewControl.cs
@@ -631,6 +631,8 @@ namespace ReClassNET.UI
 
 				Invalidate();
 			}
+
+			Focus();
 		}
 
 		#endregion


### PR DESCRIPTION
Show EditBox for the name of the current node (if it has one) when F2 is pressed. Return focus to the MemoryView when EditBox commits.