### PR TITLE
Add support for string types in C# code generator

### DIFF
--- a/ReClass.NET/CodeGenerator/CSharpCodeGenerator.cs
+++ b/ReClass.NET/CodeGenerator/CSharpCodeGenerator.cs
@@ -174,11 +174,12 @@ namespace ReClassNET.CodeGenerator
 				var (type, attribute) = GetTypeDefinition(node);
 				if (type != null)
 				{
-					writer.WriteLine($"[FieldOffset(0x{node.Offset:X})]");
 					if (attribute != null)
 					{
 						writer.WriteLine(attribute);
 					}
+
+					writer.WriteLine($"[FieldOffset(0x{node.Offset:X})]");
 					writer.Write($"public readonly {type} {node.Name};");
 					if (!string.IsNullOrEmpty(node.Comment))
 					{

--- a/ReClass.NET/CodeGenerator/CSharpCodeGenerator.cs
+++ b/ReClass.NET/CodeGenerator/CSharpCodeGenerator.cs
@@ -37,7 +37,7 @@ namespace ReClassNET.CodeGenerator
 			[typeof(Vector2Node)] = "Vector2",
 			[typeof(Vector3Node)] = "Vector3",
 			[typeof(Vector4Node)] = "Vector4"
-        };
+		};
 
 		public Language Language => Language.CSharp;
 
@@ -77,18 +77,39 @@ namespace ReClassNET.CodeGenerator
 				.Where(c => c.Nodes.None(n => n is FunctionNode)) // Skip class which contains FunctionNodes because these are not data classes.
 				.Distinct();
 
+			var unicodeStringClassLengthsToGenerate = new HashSet<int>();
+
 			using (var en = classesToWrite.GetEnumerator())
 			{
 				if (en.MoveNext())
 				{
+					void FindUnicodeStringClasses(IEnumerable<BaseNode> nodes)
+					{
+						unicodeStringClassLengthsToGenerate.UnionWith(nodes.OfType<Utf16TextNode>().Select(n => n.Length));
+					}
+
+					FindUnicodeStringClasses(en.Current!.Nodes);
+
 					WriteClass(iw, en.Current, logger);
 
 					while (en.MoveNext())
 					{
 						iw.WriteLine();
 
+						FindUnicodeStringClasses(en.Current!.Nodes);
+
 						WriteClass(iw, en.Current, logger);
 					}
+				}
+			}
+
+			if (unicodeStringClassLengthsToGenerate.Any())
+			{
+				foreach (var length in unicodeStringClassLengthsToGenerate)
+				{
+					iw.WriteLine();
+
+					WriteUnicodeStringClass(iw, length);
 				}
 			}
 
@@ -152,7 +173,7 @@ namespace ReClassNET.CodeGenerator
 			Contract.Requires(@class != null);
 			Contract.Requires(logger != null);
 
-			writer.WriteLine("[StructLayout(LayoutKind.Explicit)]");
+			writer.WriteLine("[StructLayout(LayoutKind.Explicit, CharSet = CharSet.Ansi)]");
 			writer.Write("public struct ");
 			writer.Write(@class.Name);
 
@@ -199,10 +220,10 @@ namespace ReClassNET.CodeGenerator
 		}
 
 		/// <summary>
-		/// Gets the type definition for the given node. If the node is not a simple node <c>null</c> is returned.
+		/// Gets the type definition for the given node. If the node is not expressible <c>null</c> as typename is returned.
 		/// </summary>
 		/// <param name="node">The target node.</param>
-		/// <returns>The type definition for the node or null if no simple type is available.</returns>
+		/// <returns>The type definition for the node or null as typename if the node is not expressible.</returns>
 		private static (string typeName, string attribute) GetTypeDefinition(BaseNode node)
 		{
 			Contract.Requires(node != null);
@@ -219,17 +240,36 @@ namespace ReClassNET.CodeGenerator
 				return (type, null);
 			}
 
-			if (node is EnumNode enumNode)
+			return node switch
 			{
-				return (enumNode.Enum.Name, null);
-			}
+				EnumNode enumNode => (enumNode.Enum.Name, null),
+				Utf8TextNode utf8TextNode => ("string", $"[MarshalAs(UnmanagedType.ByValTStr, SizeConst = {utf8TextNode.Length})]"),
+				Utf16TextNode utf16TextNode => (GetUnicodeStringClassName(utf16TextNode.Length), "[MarshalAs(UnmanagedType.Struct)]"),
+				_ => (null, null)
+			};
+		}
 
-			if (node is Utf8TextNode utf8TextNode)
-			{
-				return ("string", $"[MarshalAs(UnmanagedType.ByValTStr, SizeConst = {utf8TextNode.Length})]");
-			}
+		private static string GetUnicodeStringClassName(int length) => $"__UnicodeString{length}";
 
-			return (null, null);
+		/// <summary>
+		/// Writes a helper class for unicode strings with the specific length.
+		/// </summary>
+		/// <param name="writer">The writer to output to.</param>
+		/// <param name="length">The string length for this class.</param>
+		private static void WriteUnicodeStringClass(IndentedTextWriter writer, int length)
+		{
+			var className = GetUnicodeStringClassName(length);
+
+			writer.WriteLine("[StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]");
+			writer.WriteLine($"public struct {className}");
+			writer.WriteLine("{");
+			writer.Indent++;
+			writer.WriteLine($"[MarshalAs(UnmanagedType.ByValTStr, SizeConst = {length})]");
+			writer.WriteLine("public string Value;");
+			writer.WriteLine();
+			writer.WriteLine($"public static implicit operator string({className} value) => value.Value;");
+			writer.Indent--;
+			writer.WriteLine("}");
 		}
 	}
 }

--- a/ReClass.NET/CodeGenerator/CSharpCodeGenerator.cs
+++ b/ReClass.NET/CodeGenerator/CSharpCodeGenerator.cs
@@ -174,7 +174,8 @@ namespace ReClassNET.CodeGenerator
 				var type = GetTypeDefinition(node);
 				if (type != null)
 				{
-					writer.Write($"[FieldOffset(0x{node.Offset:X})] public readonly {type} {node.Name};");
+					writer.WriteLine($"[FieldOffset(0x{node.Offset:X})]");
+					writer.Write($"public readonly {type} {node.Name};");
 					if (!string.IsNullOrEmpty(node.Comment))
 					{
 						writer.Write(" ");

--- a/ReClass.NET/CodeGenerator/CSharpCodeGenerator.cs
+++ b/ReClass.NET/CodeGenerator/CSharpCodeGenerator.cs
@@ -178,7 +178,7 @@ namespace ReClassNET.CodeGenerator
 					writer.Write($"public readonly {type} {node.Name};");
 					if (!string.IsNullOrEmpty(node.Comment))
 					{
-						writer.Write(" ");
+						writer.Write(" //");
 						writer.Write(node.Comment);
 					}
 					writer.WriteLine();


### PR DESCRIPTION
This PR fixes #149.

`Utf8TextNode`s are supported with a `MarshalAs(UnmanagedType.ByValTStr)` attribute.
For `Utf16TextNode`s helper classes are generated.