### PR TITLE
Fix RegisterExtension double quoted path

### DIFF
--- a/ReClass.NET/Native/NativeMethods.Windows.cs
+++ b/ReClass.NET/Native/NativeMethods.Windows.cs
@@ -188,11 +188,6 @@ namespace ReClassNET.Native
 
 					using (var icon = extensionInfoKey?.CreateSubKey("DefaultIcon"))
 					{
-						if (applicationPath.IndexOfAny(new[] { ' ', '\t' }) < 0)
-						{
-							applicationPath = "\"" + applicationPath + "\"";
-						}
-
 						icon?.SetValue(string.Empty, "\"" + applicationPath + "\",0", RegistryValueKind.String);
 					}
 


### PR DESCRIPTION
In the latest version with all commits, if you you click the Create Association button you get:

```
Computer\HKEY_CLASSES_ROOT\rcnetfile\DefaultIcon
""C:\ReClass.NET\bin\Release\ReClass.NET_Launcher.exe"",0

Computer\HKEY_CLASSES_ROOT\rcnetfile\shell\open\command
""C:\ReClass.NET\bin\\Release\ReClass.NET_Launcher.exe"" "%1"
```

The RegisterExtension function results in a double set of quotes surrounding the path.  The double set of quotes invalidate the path and breaks the association with the icon and command keys.

Removing these 3 lines fixes it.  I tested it on file paths that contain spaces and paths that do not contain spaces in them and this fix works fine for both scenarios.
