### PR TITLE
Adding containerized linux builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ clean_release:
 	cd NativeCore/Unix && make clean_release
 	rm -rf build/Release
 
+test:
+	echo ${PWD}
+	echo ${USER}
+
 update:
 	cd ReClass.NET && make update
 
@@ -37,12 +41,12 @@ docker_all:
 docker_debug:
 	cd ReClass.NET_Launcher && make docker_debug
 	cd ReClass.NET && make docker_debug
-	docker container run --rm -v ${PWD}:/build:z -w /build gcc:latest bash -c "cd NativeCore/Unix && make debug"
+	docker container run --rm -v ${PWD}:/build:z -w /build -u $(shell id -u ${USER}):$(shell id -g ${USER}) gcc:latest bash -c "cd NativeCore/Unix && make debug"
 
 docker_release:
 	cd ReClass.NET_Launcher && make docker_release
 	cd ReClass.NET && make docker_release
-	docker container run --rm -v ${PWD}:/build:z -w /build gcc:latest bash -c "cd NativeCore/Unix && make release"
+	docker container run --rm -v ${PWD}:/build:z -w /build -u $(shell id -u ${USER}):$(shell id -g ${USER}) gcc:latest bash -c "cd NativeCore/Unix && make release"
 
 podman_all:
 	make podman_debug

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: all clean debug clean_debug release clean_release update docker_all docker_debug docker_release podman_all podman_debug podman_release dist
+
 all: debug release dist
 
 clean: clean_debug clean_release
@@ -26,6 +28,36 @@ clean_release:
 
 update:
 	cd ReClass.NET && make update
+
+docker_all:
+	make docker_debug
+	make docker_release
+	make dist
+
+docker_debug:
+	cd ReClass.NET_Launcher && make docker_debug
+	cd ReClass.NET && make docker_debug
+	docker container run --rm -v ${PWD}:/build:z -w /build gcc:latest bash -c "cd NativeCore/Unix && make debug"
+
+docker_release:
+	cd ReClass.NET_Launcher && make docker_release
+	cd ReClass.NET && make docker_release
+	docker container run --rm -v ${PWD}:/build:z -w /build gcc:latest bash -c "cd NativeCore/Unix && make release"
+
+podman_all:
+	make podman_debug
+	make podman_release
+	make dist
+
+podman_debug:
+	cd ReClass.NET_Launcher && make podman_debug
+	cd ReClass.NET && make podman_debug
+	podman container run --rm -v ${PWD}:/build:z -w /build gcc:latest bash -c "cd NativeCore/Unix && make debug"
+
+podman_release:
+	cd ReClass.NET_Launcher && make podman_release
+	cd ReClass.NET && make podman_release
+	podman container run --rm -v ${PWD}:/build:z -w /build gcc:latest bash -c "cd NativeCore/Unix && make release"
 
 dist:
 	test -d build || mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,6 @@ clean_release:
 	cd NativeCore/Unix && make clean_release
 	rm -rf build/Release
 
-test:
-	echo ${PWD}
-	echo ${USER}
-
 update:
 	cd ReClass.NET && make update
 

--- a/ReClass.NET/Makefile
+++ b/ReClass.NET/Makefile
@@ -1,3 +1,5 @@
+.PHONY: all clean debug clean_debug release clean_release update docker_debug docker_release podman_debug podman_release
+
 all: debug release
 
 clean: clean_debug clean_release
@@ -18,3 +20,19 @@ clean_release:
 
 update:
 	mono --runtime=v4.0 ../Dependencies/nuget.exe restore ReClass.NET.csproj -SolutionDirectory ../
+
+docker_debug:
+	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Debug /p:Platform=x86 ReClass.NET.csproj"
+	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Debug /p:Platform=x64 ReClass.NET.csproj"
+
+docker_release:
+	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Release /p:Platform=x86 ReClass.NET.csproj"
+	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Release /p:Platform=x64 ReClass.NET.csproj"
+
+podman_debug:
+	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Debug /p:Platform=x86 ReClass.NET.csproj"
+	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Debug /p:Platform=x64 ReClass.NET.csproj"
+
+podman_release:
+	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Release /p:Platform=x86 ReClass.NET.csproj"
+	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Release /p:Platform=x64 ReClass.NET.csproj"

--- a/ReClass.NET/Makefile
+++ b/ReClass.NET/Makefile
@@ -22,12 +22,12 @@ update:
 	mono --runtime=v4.0 ../Dependencies/nuget.exe restore ReClass.NET.csproj -SolutionDirectory ../
 
 docker_debug:
-	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Debug /p:Platform=x86 ReClass.NET.csproj"
-	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Debug /p:Platform=x64 ReClass.NET.csproj"
+	docker container run --rm -v ${PWD}/..:/build:z -w /build -u $(shell id -u ${USER}):$(shell id -g ${USER}) mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Debug /p:Platform=x86 ReClass.NET.csproj"
+	docker container run --rm -v ${PWD}/..:/build:z -w /build -u $(shell id -u ${USER}):$(shell id -g ${USER}) mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Debug /p:Platform=x64 ReClass.NET.csproj"
 
 docker_release:
-	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Release /p:Platform=x86 ReClass.NET.csproj"
-	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Release /p:Platform=x64 ReClass.NET.csproj"
+	docker container run --rm -v ${PWD}/..:/build:z -w /build -u $(shell id -u ${USER}):$(shell id -g ${USER}) mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Release /p:Platform=x86 ReClass.NET.csproj"
+	docker container run --rm -v ${PWD}/..:/build:z -w /build -u $(shell id -u ${USER}):$(shell id -g ${USER}) mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Release /p:Platform=x64 ReClass.NET.csproj"
 
 podman_debug:
 	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET && msbuild /p:Configuration=Debug /p:Platform=x86 ReClass.NET.csproj"

--- a/ReClass.NET_Launcher/Makefile
+++ b/ReClass.NET_Launcher/Makefile
@@ -1,3 +1,5 @@
+.PHONY: all clean debug clean_debug release clean_release docker_debug docker_release podman_debug podman_release
+
 all: debug release
 
 clean: clean_debug clean_release
@@ -13,3 +15,15 @@ release:
 
 clean_release:
 	msbuild /t:Clean ReClass.NET_Launcher.csproj
+
+docker_debug:
+	docker container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET_Launcher && msbuild /p:Configuration=Debug ReClass.NET_Launcher.csproj"
+
+docker_release:
+	docker container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET_Launcher && msbuild /p:Configuration=Release ReClass.NET_Launcher.csproj"
+
+podman_debug:
+	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET_Launcher && msbuild /p:Configuration=Debug ReClass.NET_Launcher.csproj"
+
+podman_release:
+	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET_Launcher && msbuild /p:Configuration=Release ReClass.NET_Launcher.csproj"

--- a/ReClass.NET_Launcher/Makefile
+++ b/ReClass.NET_Launcher/Makefile
@@ -17,10 +17,10 @@ clean_release:
 	msbuild /t:Clean ReClass.NET_Launcher.csproj
 
 docker_debug:
-	docker container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET_Launcher && msbuild /p:Configuration=Debug ReClass.NET_Launcher.csproj"
+	docker container run --rm -v ${PWD}/..:/build:z -w /build -u $(shell id -u ${USER}):$(shell id -g ${USER}) mono:latest bash -c "cd ReClass.NET_Launcher && msbuild /p:Configuration=Debug ReClass.NET_Launcher.csproj"
 
 docker_release:
-	docker container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET_Launcher && msbuild /p:Configuration=Release ReClass.NET_Launcher.csproj"
+	docker container run --rm -v ${PWD}/..:/build:z -w /build -u $(shell id -u ${USER}):$(shell id -g ${USER}) mono:latest bash -c "cd ReClass.NET_Launcher && msbuild /p:Configuration=Release ReClass.NET_Launcher.csproj"
 
 podman_debug:
 	podman container run --rm -v ${PWD}/..:/build:z -w /build mono:latest bash -c "cd ReClass.NET_Launcher && msbuild /p:Configuration=Debug ReClass.NET_Launcher.csproj"


### PR DESCRIPTION
To make it simpler to build ReClass.NET on Linux systems this change introduces a way to build ReClass without having to set up GCC or MSBuild (as this process can be a bit tedious on some distributions).

Instead of manually installing those dependencies we just load a docker environment and build them there now.

The new commands are:
make docker_all/docker_debug/docker_release
make podman_all/podman_debug/podman_release

`make docker_all` and `make podman_all` will already invoke the `make dist` step automatically.