### PR TITLE
Adds appveyor for x86, x64 and combined build on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+image: Visual Studio 2019
+
+cache:
+- Bin\$(configuration)\
+
+before_build:
+  - findstr /V "{48C5258A-FA49-4173-AEE5-0FCA5190DFF2}.Debug {48C5258A-FA49-4173-AEE5-0FCA5190DFF2}.Release" .\ReClass.NET.sln > cleaned.sln
+  - rm ReClass.NET.sln
+  - nuget restore
+  
+platform: 
+  - x86
+  - x64
+ 
+configuration: Release
+
+build:
+  project: cleaned.sln
+  verbosity: minimal
+
+artifacts:
+  - 
+    path: Bin\$(configuration)\$(platform)\*\.exe
+    path: Bin\$(configuration)\$(platform)\*\.dll
+    name: Reclass.NET $(platform)
+    type: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,6 @@ for:
   - cd %APPVEYOR_BUILD_FOLDER% # CD into the cloned project folder
   - cd Bin # CD into  Bin
   - cd Release # CD into Release
-  - set BUILD_ARCHIVE=%APPVEYOR_PROJECT_NAME%-%CONFIGURATION%-%PLATFORM%.zip # Set our output archive as projectname-(Debug|Release)-(x86|x64)
+  - set BUILD_ARCHIVE=%APPVEYOR_PROJECT_NAME%.zip # Set our output archive as projectname-(Debug|Release)-(x86|x64)
   - cmd: 7z a -r %BUILD_ARCHIVE% *.dll *.exe # Add all exe and dll files to our archive
   - appveyor PushArtifact %BUILD_ARCHIVE% # Upload the archive as an artifact

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,35 +2,64 @@ image: Visual Studio 2019
 
 environment:
   matrix:
-  - job_name: Package
+      - job_name: Windows Builds x86
+        job_group: build
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
-platform: 
-  - x86
-  - x64
- 
-configuration: Release
+      - job_name: Windows Builds x64
+        job_group: build
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+
+      - job_name: Build Combined
+        job_depends_on: build
+        APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+
 
 before_build:
   - findstr /V "{48C5258A-FA49-4173-AEE5-0FCA5190DFF2}.Debug {48C5258A-FA49-4173-AEE5-0FCA5190DFF2}.Release" .\ReClass.NET.sln > cleaned.sln # This removes the .Unix project from the solution another option would be to create a custom target inside the project
   - rm ReClass.NET.sln
   - nuget restore # restore nuget dependencies
 
-# Build the solution with the name cleaned.sln
-build:
-  project: cleaned.sln
-  verbosity: minimal
-
-# job-specific configurations
 for:
-  -
-    matrix:
-      only:
-        - job_name: Package
-    build_script:
-    - echo Job 1
+# ======================================
+#      Build
+# ======================================
+-
+  matrix:
+    only:
+    - job_name: Windows Builds x86
+  # Build the solution with the name cleaned.sln
+  # Build the solution with the name cleaned.sln
+  build_script:
+    - cd %APPVEYOR_BUILD_FOLDER% # CD into the cloned project folder
+    - msbuild "cleaned.sln" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=Release /property:Platform=x86
 
-# Package the builded files into a zip and push as artifacts
-after_build:
+-
+  matrix:
+    only:
+    - job_name: Windows Builds x64
+    
+  # Build the solution with the name cleaned.sln
+  build_script:
+    - cd %APPVEYOR_BUILD_FOLDER% # CD into the cloned project folder
+    - msbuild "cleaned.sln" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=Release /property:Platform=x64
+
+
+# ======================================
+#      Release
+# ======================================
+-
+  matrix:
+    only:
+    - job_name: Build Combined
+
+  build_script:
+  - cd %APPVEYOR_BUILD_FOLDER% # CD into the cloned project folder
+  - msbuild "cleaned.sln" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=Release /property:Platform=x86
+  - msbuild "cleaned.sln" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=Release /property:Platform=x64
+    
+  # Package the builded files into a zip and push as artifacts
+  after_build:
   - cd %APPVEYOR_BUILD_FOLDER% # CD into the cloned project folder
   - cd Bin # CD into  Bin
   - cd Release # CD into Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,39 @@
 image: Visual Studio 2019
 
-before_build:
-  - findstr /V "{48C5258A-FA49-4173-AEE5-0FCA5190DFF2}.Debug {48C5258A-FA49-4173-AEE5-0FCA5190DFF2}.Release" .\ReClass.NET.sln > cleaned.sln # This removes the .Unix project from the solution another option would be to create a custom target inside the project
-  - rm ReClass.NET.sln
-  - nuget restore # restore nuget dependencies
-  
+environment:
+  matrix:
+  - job_name: Package
+
 platform: 
   - x86
   - x64
  
 configuration: Release
 
+before_build:
+  - findstr /V "{48C5258A-FA49-4173-AEE5-0FCA5190DFF2}.Debug {48C5258A-FA49-4173-AEE5-0FCA5190DFF2}.Release" .\ReClass.NET.sln > cleaned.sln # This removes the .Unix project from the solution another option would be to create a custom target inside the project
+  - rm ReClass.NET.sln
+  - nuget restore # restore nuget dependencies
+
+# Build the solution with the name cleaned.sln
 build:
   project: cleaned.sln
   verbosity: minimal
 
+# job-specific configurations
+for:
+  -
+    matrix:
+      only:
+        - job_name: Package
+    build_script:
+    - echo Job 1
+
+# Package the builded files into a zip and push as artifacts
 after_build:
   - cd %APPVEYOR_BUILD_FOLDER% # CD into the cloned project folder
-  - cd Bin # CD into the bin
+  - cd Bin # CD into  Bin
+  - cd Release # CD into Release
   - set BUILD_ARCHIVE=%APPVEYOR_PROJECT_NAME%-%CONFIGURATION%-%PLATFORM%.zip # Set our output archive as projectname-(Debug|Release)-(x86|x64)
   - cmd: 7z a -r %BUILD_ARCHIVE% *.dll *.exe # Add all exe and dll files to our archive
   - appveyor PushArtifact %BUILD_ARCHIVE% # Upload the archive as an artifact

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,9 @@
 image: Visual Studio 2019
 
-cache:
-- Bin\$(configuration)\
-
 before_build:
-  - findstr /V "{48C5258A-FA49-4173-AEE5-0FCA5190DFF2}.Debug {48C5258A-FA49-4173-AEE5-0FCA5190DFF2}.Release" .\ReClass.NET.sln > cleaned.sln
+  - findstr /V "{48C5258A-FA49-4173-AEE5-0FCA5190DFF2}.Debug {48C5258A-FA49-4173-AEE5-0FCA5190DFF2}.Release" .\ReClass.NET.sln > cleaned.sln # This removes the .Unix project from the solution another option would be to create a custom target inside the project
   - rm ReClass.NET.sln
-  - nuget restore
+  - nuget restore # restore nuget dependencies
   
 platform: 
   - x86
@@ -18,9 +15,9 @@ build:
   project: cleaned.sln
   verbosity: minimal
 
-artifacts:
-  - 
-    path: Bin\$(configuration)\$(platform)\*\.exe
-    path: Bin\$(configuration)\$(platform)\*\.dll
-    name: Reclass.NET $(platform)
-    type: zip
+after_build:
+  - cd %APPVEYOR_BUILD_FOLDER% # CD into the cloned project folder
+  - cd Bin # CD into the bin
+  - set BUILD_ARCHIVE=%APPVEYOR_PROJECT_NAME%-%CONFIGURATION%-%PLATFORM%.zip # Set our output archive as projectname-(Debug|Release)-(x86|x64)
+  - cmd: 7z a -r %BUILD_ARCHIVE% *.dll *.exe # Add all exe and dll files to our archive
+  - appveyor PushArtifact %BUILD_ARCHIVE% # Upload the archive as an artifact


### PR DESCRIPTION
Hey,

this PR adds AppVeyor support for the Reclass.NET solution without the linux project.
The appveyor pipeline will build the solution on both x86, x64 configurations on windows with tests.
If successful a combined build that packages both executables into one zip will be triggered.