### PR TITLE
Fixed compilation on gcc 11 and fixed new import paths for dlopen/dlsym/dlcose (#220)

### DIFF
--- a/NativeCore/Unix/EnumerateRemoteSectionsAndModules.cpp
+++ b/NativeCore/Unix/EnumerateRemoteSectionsAndModules.cpp
@@ -50,7 +50,7 @@ extern "C" void RC_CallConv EnumerateRemoteSectionsAndModules(RC_Pointer handle,
 		RC_UnicodeChar Path[PATH_MAXIMUM_LENGTH] = {};
 	};
 
-	std::ifstream input(static_cast<std::stringstream&>(std::stringstream() << "/proc/" << reinterpret_cast<intptr_t>(handle) << "/maps").str());
+	std::ifstream input((std::stringstream() << "/proc/" << reinterpret_cast<intptr_t>(handle) << "/maps").str());
 
 	std::unordered_map<int, ModuleInfo> modules;
 

--- a/ReClass.NET/Native/NativeMethods.Unix.cs
+++ b/ReClass.NET/Native/NativeMethods.Unix.cs
@@ -10,13 +10,13 @@ namespace ReClassNET.Native
 
 		private const int RTLD_NOW = 2;
 
-		[DllImport("libdl.so")]
+		[DllImport("__Internal")]
 		private static extern IntPtr dlopen(string fileName, int flags);
 
-		[DllImport("libdl.so")]
+		[DllImport("__Internal")]
 		private static extern IntPtr dlsym(IntPtr handle, string symbol);
 
-		[DllImport("libdl.so")]
+		[DllImport("__Internal")]
 		private static extern int dlclose(IntPtr handle);
 
 		#endregion


### PR DESCRIPTION
When trying to compile NativeCore/Unix on my System i encountered this compilation error:
```
EnumerateRemoteSectionsAndModules.cpp: In function 'void EnumerateRemoteSectionsAndModules(RC_Pointer, void (*)(EnumerateRemoteSectionData*), void (*)(EnumerateRemoteModuleData*))':
EnumerateRemoteSectionsAndModules.cpp:53:29: error: invalid 'static_cast' from type 'std::__cxx11::basic_stringstream<char>' to type 'std::stringstream&' {aka 'std::__cxx11::basic_stringstream<char>&'}
   53 |         std::ifstream input(static_cast<std::stringstream&>(std::stringstream() << "/proc/" << reinterpret_cast<intptr_t>(handle) << "/maps").str());
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Additionally libdl.so is not needed for dlopen/dlsym/dlclose anymore as it was moved in libc. However libc might not be the best choice hence I decided to link it to `__Internal` which should give better results on more configurations.