### PR TITLE
Add setting for optional zip compression (different approach)

### DIFF
--- a/ReClass.NET/DataExchange/ReClass/ReClassDataFile.Constants.cs
+++ b/ReClass.NET/DataExchange/ReClass/ReClassDataFile.Constants.cs
@@ -1,0 +1,41 @@
+namespace ReClassNET.DataExchange.ReClass
+{
+	public partial class ReClassDataFile
+	{
+		public const string FormatName = "ReClass.NET Data File";
+		public const string FileExtension = ".xml";
+		public const string FileExtensionId = "rcdatafile";
+
+		private const uint FileVersion = 0x00010001;
+		private const uint FileVersionCriticalMask = 0xFFFF0000;
+
+		private const string SerializationClassName = "__Serialization_Class__";
+
+		public const string XmlRootElement = "reclass";
+		public const string XmlCustomDataElement = "custom_data";
+		public const string XmlTypeMappingElement = "type_mapping";
+		public const string XmlEnumsElement = "enums";
+		public const string XmlEnumElement = "enum";
+		public const string XmlClassesElement = "classes";
+		public const string XmlClassElement = "class";
+		public const string XmlNodeElement = "node";
+		public const string XmlMethodElement = "method";
+		public const string XmlVersionAttribute = "version";
+		public const string XmlPlatformAttribute = "type";
+		public const string XmlUuidAttribute = "uuid";
+		public const string XmlNameAttribute = "name";
+		public const string XmlCommentAttribute = "comment";
+		public const string XmlHiddenAttribute = "hidden";
+		public const string XmlAddressAttribute = "address";
+		public const string XmlTypeAttribute = "type";
+		public const string XmlReferenceAttribute = "reference";
+		public const string XmlCountAttribute = "count";
+		public const string XmlBitsAttribute = "bits";
+		public const string XmlLengthAttribute = "length";
+		public const string XmlSizeAttribute = "size";
+		public const string XmlSignatureAttribute = "signature";
+		public const string XmlFlagsAttribute = "flags";
+		public const string XmlItemElement = "item";
+		public const string XmlValueAttribute = "value";
+	}
+}

--- a/ReClass.NET/DataExchange/ReClass/ReClassDataFile.Read.cs
+++ b/ReClass.NET/DataExchange/ReClass/ReClassDataFile.Read.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
+using ReClassNET.DataExchange.ReClass.Legacy;
+using ReClassNET.Extensions;
+using ReClassNET.Logger;
+using ReClassNET.Nodes;
+using ReClassNET.Project;
+
+namespace ReClassNET.DataExchange.ReClass
+{
+	public partial class ReClassDataFile
+	{
+		public void Load(string filePath, ILogger logger)
+		{
+			using var fs = new FileStream(filePath, FileMode.Open);
+
+			Load(fs, logger);
+		}
+
+		public void Load(Stream input, ILogger logger)
+		{
+			Contract.Requires(input != null);
+			Contract.Requires(logger != null);
+
+			var document = XDocument.Load(input);
+			if (document.Root?.Element(XmlClassesElement) == null)
+			{
+				throw new FormatException("The data has not the correct format.");
+			}
+
+			uint.TryParse(document.Root.Attribute(XmlVersionAttribute)?.Value, out var fileVersion);
+			if ((fileVersion & FileVersionCriticalMask) > (FileVersion & FileVersionCriticalMask))
+			{
+				throw new FormatException($"The file version is unsupported. A newer {Constants.ApplicationName} version is required to read it.");
+			}
+
+			var platform = document.Root.Attribute(XmlPlatformAttribute)?.Value;
+			if (platform != Constants.Platform)
+			{
+				logger.Log(LogLevel.Warning, $"The platform of the file ({platform}) doesn't match the program platform ({Constants.Platform}).");
+			}
+
+			var customDataElement = document.Root.Element(XmlCustomDataElement);
+			if (customDataElement != null)
+			{
+				project.CustomData.Deserialize(customDataElement);
+			}
+
+			var typeMappingElement = document.Root.Element(XmlTypeMappingElement);
+			if (typeMappingElement != null)
+			{
+				project.TypeMapping.Deserialize(typeMappingElement);
+			}
+
+			var enumsElement = document.Root.Element(XmlEnumsElement);
+			if (enumsElement != null)
+			{
+				foreach (var enumElement in enumsElement.Elements(XmlEnumElement))
+				{
+					var name = enumElement.Attribute(XmlNameAttribute)?.Value ?? string.Empty;
+					var useFlagsMode = (bool?)enumElement.Attribute(XmlFlagsAttribute) ?? false;
+					var size = enumElement.Attribute(XmlSizeAttribute).GetEnumValue<EnumDescription.UnderlyingTypeSize>();
+
+					var values = new Dictionary<string, long>();
+					foreach (var itemElement in enumElement.Elements(XmlItemElement))
+					{
+						var itemName = itemElement.Attribute(XmlNameAttribute)?.Value ?? string.Empty;
+						var itemValue = (long?)itemElement.Attribute(XmlValueAttribute) ?? 0L;
+
+						values.Add(itemName, itemValue);
+					}
+
+					var @enum = new EnumDescription
+					{
+						Name = name
+					};
+					@enum.SetData(useFlagsMode, size, values);
+
+					project.AddEnum(@enum);
+				}
+			}
+
+			var classes = new List<(XElement, ClassNode)>();
+
+			var classesElement = document.Root.Element(XmlClassesElement);
+			if (classesElement != null)
+			{
+				foreach (var element in classesElement
+					.Elements(XmlClassElement)
+					.DistinctBy(e => e.Attribute(XmlUuidAttribute)?.Value))
+				{
+					var node = new ClassNode(false)
+					{
+						Uuid = ParseUuid(element.Attribute(XmlUuidAttribute)?.Value),
+						Name = element.Attribute(XmlNameAttribute)?.Value ?? string.Empty,
+						Comment = element.Attribute(XmlCommentAttribute)?.Value ?? string.Empty,
+						AddressFormula = element.Attribute(XmlAddressAttribute)?.Value ?? string.Empty
+					};
+
+					if (!project.ContainsClass(node.Uuid))
+					{
+						project.AddClass(node);
+
+						classes.Add((element, node));
+					}
+				}
+			}
+
+			foreach (var (element, classNode) in classes)
+			{
+				var nodes = element.Elements(XmlNodeElement)
+					.Select(e => CreateNodeFromElement(e, classNode, logger))
+					.Where(n => n != null);
+
+				classNode.BeginUpdate();
+				classNode.AddNodes(nodes);
+				classNode.EndUpdate();
+			}
+		}
+
+		private BaseNode CreateNodeFromElement(XElement element, BaseNode parent, ILogger logger)
+		{
+			Contract.Requires(element != null);
+			Contract.Requires(logger != null);
+
+			BaseNode CreateNode()
+			{
+				var converter = CustomNodeSerializer.GetReadConverter(element);
+				if (converter != null)
+				{
+					return converter.CreateNodeFromElement(element, parent, project.Classes, logger, CreateNodeFromElement);
+				}
+
+				if (!buildInStringToTypeMap.TryGetValue(element.Attribute(XmlTypeAttribute)?.Value ?? string.Empty, out var nodeType))
+				{
+					logger.Log(LogLevel.Error, $"Skipping node with unknown type: {element.Attribute(XmlTypeAttribute)?.Value}");
+					logger.Log(LogLevel.Warning, element.ToString());
+
+					return null;
+				}
+
+				return BaseNode.CreateInstanceFromType(nodeType, false);
+			}
+
+			var node = CreateNode();
+			if (node == null)
+			{
+				logger.Log(LogLevel.Error, "Could not create node.");
+
+				return null;
+			}
+
+			node.ParentNode = parent;
+
+			node.Name = element.Attribute(XmlNameAttribute)?.Value ?? string.Empty;
+			node.Comment = element.Attribute(XmlCommentAttribute)?.Value ?? string.Empty;
+			node.IsHidden = bool.TryParse(element.Attribute(XmlHiddenAttribute)?.Value, out var val) && val;
+
+			if (node is BaseWrapperNode wrapperNode)
+			{
+				ClassNode GetClassNodeFromElementReference()
+				{
+					var reference = ParseUuid(element.Attribute(XmlReferenceAttribute)?.Value);
+					if (!project.ContainsClass(reference))
+					{
+						logger.Log(LogLevel.Error, $"Skipping node with unknown reference: {reference}");
+						logger.Log(LogLevel.Warning, element.ToString());
+
+						return null;
+					}
+
+					return project.GetClassByUuid(reference);
+				}
+
+				// Legacy Support
+				if (node is ClassPointerNode || node is ClassInstanceArrayNode || node is ClassPointerArrayNode)
+				{
+					var innerClass = GetClassNodeFromElementReference();
+					if (innerClass == null)
+					{
+						return null;
+					}
+
+					node = node switch
+					{
+						BaseClassArrayNode classArrayNode => classArrayNode.GetEquivalentNode(0, innerClass),
+						ClassPointerNode classPointerNode => classPointerNode.GetEquivalentNode(innerClass)
+					};
+				}
+				else
+				{
+					BaseNode innerNode = null;
+
+					if (node is BaseClassWrapperNode)
+					{
+						innerNode = GetClassNodeFromElementReference();
+						if (innerNode == null)
+						{
+							return null;
+						}
+					}
+					else
+					{
+						var innerElement = element.Elements().FirstOrDefault();
+						if (innerElement != null)
+						{
+							innerNode = CreateNodeFromElement(innerElement, node, logger);
+						}
+					}
+
+					if (wrapperNode.CanChangeInnerNodeTo(innerNode))
+					{
+						var rootWrapperNode = node.GetRootWrapperNode();
+						if (rootWrapperNode.ShouldPerformCycleCheckForInnerNode()
+							&& innerNode is ClassNode classNode
+							&& ClassUtil.IsCyclicIfClassIsAccessibleFromParent(node.GetParentClass(), classNode, project.Classes))
+						{
+							logger.Log(LogLevel.Error, $"Skipping node with cyclic class reference: {node.GetParentClass().Name}->{rootWrapperNode.Name}");
+
+							return null;
+						}
+
+						wrapperNode.ChangeInnerNode(innerNode);
+					}
+					else
+					{
+						logger.Log(LogLevel.Error, $"The node {innerNode} is not a valid child for {node}.");
+					}
+				}
+			}
+
+			switch (node)
+			{
+				case VirtualMethodTableNode vtableNode:
+				{
+					var nodes = element
+						.Elements(XmlMethodElement)
+						.Select(e => new VirtualMethodNode
+						{
+							Name = e.Attribute(XmlNameAttribute)?.Value ?? string.Empty,
+							Comment = e.Attribute(XmlCommentAttribute)?.Value ?? string.Empty,
+							IsHidden = (bool?)e.Attribute(XmlHiddenAttribute) ?? false
+						});
+
+					vtableNode.AddNodes(nodes);
+					break;
+				}
+				case UnionNode unionNode:
+				{
+					var nodes = element
+						.Elements()
+						.Select(e => CreateNodeFromElement(e, unionNode, logger));
+
+					unionNode.AddNodes(nodes);
+					break;
+				}
+				case BaseWrapperArrayNode arrayNode:
+				{
+					arrayNode.Count = (int?)element.Attribute(XmlCountAttribute) ?? 0;
+					break;
+				}
+				case BaseTextNode textNode:
+				{
+					textNode.Length = (int?)element.Attribute(XmlLengthAttribute) ?? 0;
+					break;
+				}
+				case BitFieldNode bitFieldNode:
+				{
+					bitFieldNode.Bits = (int?)element.Attribute(XmlBitsAttribute) ?? 0;
+					break;
+				}
+				case FunctionNode functionNode:
+				{
+					functionNode.Signature = element.Attribute(XmlSignatureAttribute)?.Value ?? string.Empty;
+
+					var reference = ParseUuid(element.Attribute(XmlReferenceAttribute)?.Value);
+					if (project.ContainsClass(reference))
+					{
+						functionNode.BelongsToClass = project.GetClassByUuid(reference);
+					}
+					break;
+				}
+				case EnumNode enumNode:
+				{
+					var enumName = element.Attribute(XmlReferenceAttribute)?.Value ?? string.Empty;
+					var @enum = project.Enums.FirstOrDefault(e => e.Name == enumName) ?? EnumDescription.Default;
+					
+					enumNode.ChangeEnum(@enum);
+					break;
+				}
+			}
+
+			return node;
+		}
+
+		private static Guid ParseUuid(string raw) => raw == null
+				? throw new ArgumentNullException()
+				: raw.Length == 24
+					? new Guid(Convert.FromBase64String(raw))
+					: Guid.Parse(raw);
+
+		public static Tuple<List<ClassNode>, List<BaseNode>> DeserializeNodesFromStream(Stream input, ReClassNetProject templateProject, ILogger logger)
+		{
+			Contract.Requires(input != null);
+			Contract.Requires(logger != null);
+			Contract.Ensures(Contract.Result<Tuple<List<ClassNode>, List<BaseNode>>>() != null);
+
+			using var project = new ReClassNetProject();
+			templateProject?.Classes.ForEach(project.AddClass);
+
+			var file = new ReClassDataFile(project);
+			file.Load(input, logger);
+
+			var classes = project.Classes
+				.Where(c => c.Name != SerializationClassName);
+			if (templateProject != null)
+			{
+				classes = classes.Where(c => !templateProject.ContainsClass(c.Uuid));
+			}
+
+			var nodes = project.Classes
+				.Where(c => c.Name == SerializationClassName)
+				.SelectMany(c => c.Nodes);
+
+			return Tuple.Create(classes.ToList(), nodes.ToList());
+		}
+	}
+}

--- a/ReClass.NET/DataExchange/ReClass/ReClassDataFile.Write.cs
+++ b/ReClass.NET/DataExchange/ReClass/ReClassDataFile.Write.cs
@@ -11,15 +11,15 @@ using ReClassNET.Project;
 
 namespace ReClassNET.DataExchange.ReClass
 {
-	public partial class ReClassNetFile
+	public partial class ReClassDataFile
 	{
 		public void Save(string filePath, ILogger logger)
 		{
 			//Adjust path according to the format we are saving in
-			if (filePath.EndsWith(ReClassDataFile.FileExtension))
+			if(filePath.EndsWith(ReClassNetFile.FileExtension))
 			{
-				filePath.Substring(0, filePath.Length - ReClassDataFile.FileExtension.Length);
-				filePath += ReClassNetFile.FileExtension;
+				filePath.Substring(0, filePath.Length - ReClassNetFile.FileExtension.Length);
+				filePath += ReClassDataFile.FileExtension;
 			}
 			using var fs = new FileStream(filePath, FileMode.Create);
 
@@ -28,11 +28,6 @@ namespace ReClassNET.DataExchange.ReClass
 
 		public void Save(Stream output, ILogger logger)
 		{
-			using var archive = new ZipArchive(output, ZipArchiveMode.Create);
-
-			var dataEntry = archive.CreateEntry(DataFileName);
-			using var entryStream = dataEntry.Open();
-
 			var document = new XDocument(
 				new XComment($"{Constants.ApplicationName} {Constants.ApplicationVersion} by {Constants.Author}"),
 				new XComment($"Website: {Constants.HomepageUrl}"),
@@ -47,7 +42,7 @@ namespace ReClassNET.DataExchange.ReClass
 				)
 			);
 
-			document.Save(entryStream);
+			document.Save(output);
 		}
 
 		private static IEnumerable<XElement> CreateEnumElements(IEnumerable<EnumDescription> enums)
@@ -241,7 +236,7 @@ namespace ReClassNET.DataExchange.ReClass
 				}
 			}
 
-			var file = new ReClassNetFile(project);
+			var file = new ReClassDataFile(project);
 			file.Save(output, logger);
 		}
 	}

--- a/ReClass.NET/DataExchange/ReClass/ReClassDataFile.cs
+++ b/ReClass.NET/DataExchange/ReClass/ReClassDataFile.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ReClassNET.DataExchange.ReClass.Legacy;
+using ReClassNET.Nodes;
+using ReClassNET.Project;
+
+namespace ReClassNET.DataExchange.ReClass
+{
+	public partial class ReClassDataFile : IReClassImport, IReClassExport
+	{
+		private readonly ReClassNetProject project;
+
+		public ReClassDataFile(ReClassNetProject project)
+		{
+			Contract.Requires(project != null);
+
+			this.project = project;
+		}
+
+		static ReClassDataFile()
+		{
+			// Obsolete: The name of the class was changed. Because of this older versions can't load these nodes.
+			buildInStringToTypeMap["UTF8TextNode"] = typeof(Utf8TextNode);
+			buildInStringToTypeMap["UTF8TextPtrNode"] = typeof(Utf8TextPtrNode);
+			buildInStringToTypeMap["UTF16TextNode"] = typeof(Utf16TextNode);
+			buildInStringToTypeMap["UTF16TextPtrNode"] = typeof(Utf16TextPtrNode);
+			buildInStringToTypeMap["UTF32TextNode"] = typeof(Utf32TextNode);
+			buildInStringToTypeMap["UTF32TextPtrNode"] = typeof(Utf32TextPtrNode);
+			buildInStringToTypeMap["VTableNode"] = typeof(VirtualMethodTableNode);
+
+			// Legacy
+			buildInStringToTypeMap["ClassInstanceArrayNode"] = typeof(ClassInstanceArrayNode);
+			buildInStringToTypeMap["ClassPtrArrayNode"] = typeof(ClassPointerArrayNode);
+			buildInStringToTypeMap["ClassPtrNode"] = typeof(ClassPointerNode);
+		}
+
+		private static readonly Dictionary<string, Type> buildInStringToTypeMap = new[]
+		{
+			typeof(BoolNode),
+			typeof(BitFieldNode),
+			typeof(EnumNode),
+			typeof(ClassInstanceNode),
+			typeof(DoubleNode),
+			typeof(FloatNode),
+			typeof(FunctionNode),
+			typeof(FunctionPtrNode),
+			typeof(Hex8Node),
+			typeof(Hex16Node),
+			typeof(Hex32Node),
+			typeof(Hex64Node),
+			typeof(Int8Node),
+			typeof(Int16Node),
+			typeof(Int32Node),
+			typeof(Int64Node),
+			typeof(NIntNode),
+			typeof(Matrix3x3Node),
+			typeof(Matrix3x4Node),
+			typeof(Matrix4x4Node),
+			typeof(UInt8Node),
+			typeof(UInt16Node),
+			typeof(UInt32Node),
+			typeof(UInt64Node),
+			typeof(NUIntNode),
+			typeof(Utf8TextNode),
+			typeof(Utf8TextPtrNode),
+			typeof(Utf16TextNode),
+			typeof(Utf16TextPtrNode),
+			typeof(Utf32TextNode),
+			typeof(Utf32TextPtrNode),
+			typeof(Vector2Node),
+			typeof(Vector3Node),
+			typeof(Vector4Node),
+			typeof(VirtualMethodTableNode),
+			typeof(ArrayNode),
+			typeof(PointerNode),
+			typeof(UnionNode)
+		}.ToDictionary(t => t.Name, t => t);
+
+		private static readonly Dictionary<Type, string> buildInTypeToStringMap = buildInStringToTypeMap.ToDictionary(kv => kv.Value, kv => kv.Key);
+	}
+}

--- a/ReClass.NET/Forms/MainForm.Functions.cs
+++ b/ReClass.NET/Forms/MainForm.Functions.cs
@@ -197,6 +197,7 @@ namespace ReClassNET.Forms
 				         + $"|{ReClassNetFile.FormatName} (*{ReClassNetFile.FileExtension})|*{ReClassNetFile.FileExtension}"
 				         + $"|{ReClassFile.FormatName} (*{ReClassFile.FileExtension})|*{ReClassFile.FileExtension}"
 				         + $"|{ReClassQtFile.FormatName} (*{ReClassQtFile.FileExtension})|*{ReClassQtFile.FileExtension}"
+				         + $"|{ReClassDataFile.FormatName} (*{ReClassDataFile.FileExtension})|*{ReClassDataFile.FileExtension}"
 			};
 
 			if (ofd.ShowDialog() == DialogResult.OK)
@@ -217,8 +218,9 @@ namespace ReClassNET.Forms
 
 			LoadProjectFromPath(path, ref project);
 
-			// If the file is a ReClass.NET file remember the path.
-			if (Path.GetExtension(path) == ReClassNetFile.FileExtension)
+			// If the file is a ReClass.NET file or ReClass.NET Data file remember the path.
+			if (Path.GetExtension(path) == ReClassNetFile.FileExtension ||
+				Path.GetExtension(path) == ReClassDataFile.FileExtension)
 			{
 				project.Path = path;
 			}
@@ -240,6 +242,9 @@ namespace ReClassNET.Forms
 			{
 				case ReClassNetFile.FileExtension:
 					import = new ReClassNetFile(project);
+					break;
+				case ReClassDataFile.FileExtension:
+					import = new ReClassDataFile(project);
 					break;
 				case ReClassQtFile.FileExtension:
 					import = new ReClassQtFile(project);

--- a/ReClass.NET/Forms/MainForm.cs
+++ b/ReClass.NET/Forms/MainForm.cs
@@ -294,7 +294,15 @@ namespace ReClassNET.Forms
 				return;
 			}
 
-			var file = new ReClassNetFile(currentProject);
+			IReClassExport file;
+			if (Program.Settings.CompressAsZip)
+			{
+				file = new ReClassNetFile(currentProject);
+			}
+			else
+			{
+				file = new ReClassDataFile(currentProject);
+			}
 			file.Save(currentProject.Path, Program.Logger);
 		}
 

--- a/ReClass.NET/Forms/SettingsForm.Designer.cs
+++ b/ReClass.NET/Forms/SettingsForm.Designer.cs
@@ -83,6 +83,8 @@ namespace ReClassNET.Forms
             this.backgroundLabel = new System.Windows.Forms.Label();
             this.backgroundColorBox = new ReClassNET.Controls.ColorBox();
             this.typeDefinitionsSettingsTabPage = new System.Windows.Forms.TabPage();
+            this.utf32TextSettingsLabel = new System.Windows.Forms.Label();
+            this.utf32TextTypeTextBox = new System.Windows.Forms.TextBox();
             this.nuintSettingsLabel = new System.Windows.Forms.Label();
             this.nuintTypeTextBox = new System.Windows.Forms.TextBox();
             this.nintSettingsLabel = new System.Windows.Forms.Label();
@@ -129,8 +131,9 @@ namespace ReClassNET.Forms
             this.int8SettingsLabel = new System.Windows.Forms.Label();
             this.int8TypeTextBox = new System.Windows.Forms.TextBox();
             this.bannerBox = new ReClassNET.Controls.BannerBox();
-            this.utf32TextSettingsLabel = new System.Windows.Forms.Label();
-            this.utf32TextTypeTextBox = new System.Windows.Forms.TextBox();
+            this.projectSettingTabPage = new System.Windows.Forms.TabPage();
+            this.compressZipCheckBox = new System.Windows.Forms.CheckBox();
+            this.label1 = new System.Windows.Forms.Label();
             this.settingsTabControl.SuspendLayout();
             this.generalSettingsTabPage.SuspendLayout();
             this.fileAssociationGroupBox.SuspendLayout();
@@ -140,6 +143,7 @@ namespace ReClassNET.Forms
             this.nodeColorGroupBox.SuspendLayout();
             this.typeDefinitionsSettingsTabPage.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.bannerBox)).BeginInit();
+            this.projectSettingTabPage.SuspendLayout();
             this.SuspendLayout();
             // 
             // settingsTabControl
@@ -147,10 +151,12 @@ namespace ReClassNET.Forms
             this.settingsTabControl.Controls.Add(this.generalSettingsTabPage);
             this.settingsTabControl.Controls.Add(this.colorsSettingTabPage);
             this.settingsTabControl.Controls.Add(this.typeDefinitionsSettingsTabPage);
-            this.settingsTabControl.Location = new System.Drawing.Point(12, 60);
+            this.settingsTabControl.Controls.Add(this.projectSettingTabPage);
+            this.settingsTabControl.Location = new System.Drawing.Point(16, 74);
+            this.settingsTabControl.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.settingsTabControl.Name = "settingsTabControl";
             this.settingsTabControl.SelectedIndex = 0;
-            this.settingsTabControl.Size = new System.Drawing.Size(562, 355);
+            this.settingsTabControl.Size = new System.Drawing.Size(749, 437);
             this.settingsTabControl.TabIndex = 1;
             // 
             // generalSettingsTabPage
@@ -159,10 +165,11 @@ namespace ReClassNET.Forms
             this.generalSettingsTabPage.Controls.Add(this.commentsGroupBox);
             this.generalSettingsTabPage.Controls.Add(this.displayGroupBox);
             this.generalSettingsTabPage.Controls.Add(this.stayOnTopCheckBox);
-            this.generalSettingsTabPage.Location = new System.Drawing.Point(4, 22);
+            this.generalSettingsTabPage.Location = new System.Drawing.Point(4, 25);
+            this.generalSettingsTabPage.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.generalSettingsTabPage.Name = "generalSettingsTabPage";
-            this.generalSettingsTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.generalSettingsTabPage.Size = new System.Drawing.Size(554, 329);
+            this.generalSettingsTabPage.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.generalSettingsTabPage.Size = new System.Drawing.Size(741, 408);
             this.generalSettingsTabPage.TabIndex = 0;
             this.generalSettingsTabPage.Text = "General";
             this.generalSettingsTabPage.UseVisualStyleBackColor = true;
@@ -172,9 +179,11 @@ namespace ReClassNET.Forms
             this.fileAssociationGroupBox.Controls.Add(this.removeAssociationButton);
             this.fileAssociationGroupBox.Controls.Add(this.createAssociationButton);
             this.fileAssociationGroupBox.Controls.Add(this.associationInfoLabel);
-            this.fileAssociationGroupBox.Location = new System.Drawing.Point(6, 231);
+            this.fileAssociationGroupBox.Location = new System.Drawing.Point(8, 284);
+            this.fileAssociationGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.fileAssociationGroupBox.Name = "fileAssociationGroupBox";
-            this.fileAssociationGroupBox.Size = new System.Drawing.Size(542, 85);
+            this.fileAssociationGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.fileAssociationGroupBox.Size = new System.Drawing.Size(723, 105);
             this.fileAssociationGroupBox.TabIndex = 4;
             this.fileAssociationGroupBox.TabStop = false;
             this.fileAssociationGroupBox.Text = "RCNET File Association";
@@ -182,9 +191,10 @@ namespace ReClassNET.Forms
             // removeAssociationButton
             // 
             this.removeAssociationButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.removeAssociationButton.Location = new System.Drawing.Point(146, 52);
+            this.removeAssociationButton.Location = new System.Drawing.Point(195, 64);
+            this.removeAssociationButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.removeAssociationButton.Name = "removeAssociationButton";
-            this.removeAssociationButton.Size = new System.Drawing.Size(135, 23);
+            this.removeAssociationButton.Size = new System.Drawing.Size(180, 28);
             this.removeAssociationButton.TabIndex = 2;
             this.removeAssociationButton.Text = "&Remove Association";
             this.removeAssociationButton.UseVisualStyleBackColor = true;
@@ -193,9 +203,10 @@ namespace ReClassNET.Forms
             // createAssociationButton
             // 
             this.createAssociationButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.createAssociationButton.Location = new System.Drawing.Point(9, 52);
+            this.createAssociationButton.Location = new System.Drawing.Point(12, 64);
+            this.createAssociationButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.createAssociationButton.Name = "createAssociationButton";
-            this.createAssociationButton.Size = new System.Drawing.Size(131, 23);
+            this.createAssociationButton.Size = new System.Drawing.Size(175, 28);
             this.createAssociationButton.TabIndex = 1;
             this.createAssociationButton.Text = "Create &Association";
             this.createAssociationButton.UseVisualStyleBackColor = true;
@@ -203,9 +214,10 @@ namespace ReClassNET.Forms
             // 
             // associationInfoLabel
             // 
-            this.associationInfoLabel.Location = new System.Drawing.Point(6, 21);
+            this.associationInfoLabel.Location = new System.Drawing.Point(8, 26);
+            this.associationInfoLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.associationInfoLabel.Name = "associationInfoLabel";
-            this.associationInfoLabel.Size = new System.Drawing.Size(525, 28);
+            this.associationInfoLabel.Size = new System.Drawing.Size(700, 34);
             this.associationInfoLabel.TabIndex = 0;
             this.associationInfoLabel.Text = "RCNET files can be associated with ReClass.NET. When you double-click a RCNET fil" +
     "e, they will automatically be opened by ReClass.NET.";
@@ -219,9 +231,11 @@ namespace ReClassNET.Forms
             this.commentsGroupBox.Controls.Add(this.showPointerCheckBox);
             this.commentsGroupBox.Controls.Add(this.showIntegerCheckBox);
             this.commentsGroupBox.Controls.Add(this.showFloatCheckBox);
-            this.commentsGroupBox.Location = new System.Drawing.Point(6, 39);
+            this.commentsGroupBox.Location = new System.Drawing.Point(8, 48);
+            this.commentsGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.commentsGroupBox.Name = "commentsGroupBox";
-            this.commentsGroupBox.Size = new System.Drawing.Size(265, 186);
+            this.commentsGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.commentsGroupBox.Size = new System.Drawing.Size(353, 229);
             this.commentsGroupBox.TabIndex = 3;
             this.commentsGroupBox.TabStop = false;
             this.commentsGroupBox.Text = "Node Comments";
@@ -229,9 +243,10 @@ namespace ReClassNET.Forms
             // showPluginInfoCheckBox
             // 
             this.showPluginInfoCheckBox.AutoSize = true;
-            this.showPluginInfoCheckBox.Location = new System.Drawing.Point(6, 157);
+            this.showPluginInfoCheckBox.Location = new System.Drawing.Point(8, 193);
+            this.showPluginInfoCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.showPluginInfoCheckBox.Name = "showPluginInfoCheckBox";
-            this.showPluginInfoCheckBox.Size = new System.Drawing.Size(111, 17);
+            this.showPluginInfoCheckBox.Size = new System.Drawing.Size(133, 20);
             this.showPluginInfoCheckBox.TabIndex = 6;
             this.showPluginInfoCheckBox.Text = "Show Plugin Infos";
             this.showPluginInfoCheckBox.UseVisualStyleBackColor = true;
@@ -239,9 +254,10 @@ namespace ReClassNET.Forms
             // showStringCheckBox
             // 
             this.showStringCheckBox.AutoSize = true;
-            this.showStringCheckBox.Location = new System.Drawing.Point(6, 134);
+            this.showStringCheckBox.Location = new System.Drawing.Point(8, 165);
+            this.showStringCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.showStringCheckBox.Name = "showStringCheckBox";
-            this.showStringCheckBox.Size = new System.Drawing.Size(88, 17);
+            this.showStringCheckBox.Size = new System.Drawing.Size(106, 20);
             this.showStringCheckBox.TabIndex = 5;
             this.showStringCheckBox.Text = "Show Strings";
             this.showStringCheckBox.UseVisualStyleBackColor = true;
@@ -249,9 +265,10 @@ namespace ReClassNET.Forms
             // showSymbolsCheckBox
             // 
             this.showSymbolsCheckBox.AutoSize = true;
-            this.showSymbolsCheckBox.Location = new System.Drawing.Point(6, 111);
+            this.showSymbolsCheckBox.Location = new System.Drawing.Point(8, 137);
+            this.showSymbolsCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.showSymbolsCheckBox.Name = "showSymbolsCheckBox";
-            this.showSymbolsCheckBox.Size = new System.Drawing.Size(130, 17);
+            this.showSymbolsCheckBox.Size = new System.Drawing.Size(162, 20);
             this.showSymbolsCheckBox.TabIndex = 4;
             this.showSymbolsCheckBox.Text = "Show Debug Symbols";
             this.showSymbolsCheckBox.UseVisualStyleBackColor = true;
@@ -259,9 +276,10 @@ namespace ReClassNET.Forms
             // showRttiCheckBox
             // 
             this.showRttiCheckBox.AutoSize = true;
-            this.showRttiCheckBox.Location = new System.Drawing.Point(6, 88);
+            this.showRttiCheckBox.Location = new System.Drawing.Point(8, 108);
+            this.showRttiCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.showRttiCheckBox.Name = "showRttiCheckBox";
-            this.showRttiCheckBox.Size = new System.Drawing.Size(81, 17);
+            this.showRttiCheckBox.Size = new System.Drawing.Size(96, 20);
             this.showRttiCheckBox.TabIndex = 3;
             this.showRttiCheckBox.Text = "Show RTTI";
             this.showRttiCheckBox.UseVisualStyleBackColor = true;
@@ -269,9 +287,10 @@ namespace ReClassNET.Forms
             // showPointerCheckBox
             // 
             this.showPointerCheckBox.AutoSize = true;
-            this.showPointerCheckBox.Location = new System.Drawing.Point(6, 65);
+            this.showPointerCheckBox.Location = new System.Drawing.Point(8, 80);
+            this.showPointerCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.showPointerCheckBox.Name = "showPointerCheckBox";
-            this.showPointerCheckBox.Size = new System.Drawing.Size(94, 17);
+            this.showPointerCheckBox.Size = new System.Drawing.Size(114, 20);
             this.showPointerCheckBox.TabIndex = 2;
             this.showPointerCheckBox.Text = "Show Pointers";
             this.showPointerCheckBox.UseVisualStyleBackColor = true;
@@ -279,9 +298,10 @@ namespace ReClassNET.Forms
             // showIntegerCheckBox
             // 
             this.showIntegerCheckBox.AutoSize = true;
-            this.showIntegerCheckBox.Location = new System.Drawing.Point(6, 42);
+            this.showIntegerCheckBox.Location = new System.Drawing.Point(8, 52);
+            this.showIntegerCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.showIntegerCheckBox.Name = "showIntegerCheckBox";
-            this.showIntegerCheckBox.Size = new System.Drawing.Size(124, 17);
+            this.showIntegerCheckBox.Size = new System.Drawing.Size(151, 20);
             this.showIntegerCheckBox.TabIndex = 1;
             this.showIntegerCheckBox.Text = "Show Integer Values";
             this.showIntegerCheckBox.UseVisualStyleBackColor = true;
@@ -289,9 +309,10 @@ namespace ReClassNET.Forms
             // showFloatCheckBox
             // 
             this.showFloatCheckBox.AutoSize = true;
-            this.showFloatCheckBox.Location = new System.Drawing.Point(6, 19);
+            this.showFloatCheckBox.Location = new System.Drawing.Point(8, 23);
+            this.showFloatCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.showFloatCheckBox.Name = "showFloatCheckBox";
-            this.showFloatCheckBox.Size = new System.Drawing.Size(114, 17);
+            this.showFloatCheckBox.Size = new System.Drawing.Size(140, 20);
             this.showFloatCheckBox.TabIndex = 0;
             this.showFloatCheckBox.Text = "Show Float Values";
             this.showFloatCheckBox.UseVisualStyleBackColor = true;
@@ -304,9 +325,11 @@ namespace ReClassNET.Forms
             this.displayGroupBox.Controls.Add(this.showTextCheckBox);
             this.displayGroupBox.Controls.Add(this.showNodeOffsetCheckBox);
             this.displayGroupBox.Controls.Add(this.showNodeAddressCheckBox);
-            this.displayGroupBox.Location = new System.Drawing.Point(283, 39);
+            this.displayGroupBox.Location = new System.Drawing.Point(377, 48);
+            this.displayGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.displayGroupBox.Name = "displayGroupBox";
-            this.displayGroupBox.Size = new System.Drawing.Size(265, 160);
+            this.displayGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.displayGroupBox.Size = new System.Drawing.Size(353, 197);
             this.displayGroupBox.TabIndex = 2;
             this.displayGroupBox.TabStop = false;
             this.displayGroupBox.Text = "Display";
@@ -314,9 +337,10 @@ namespace ReClassNET.Forms
             // randomizeWindowTitleCheckBox
             // 
             this.randomizeWindowTitleCheckBox.AutoSize = true;
-            this.randomizeWindowTitleCheckBox.Location = new System.Drawing.Point(6, 134);
+            this.randomizeWindowTitleCheckBox.Location = new System.Drawing.Point(8, 165);
+            this.randomizeWindowTitleCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.randomizeWindowTitleCheckBox.Name = "randomizeWindowTitleCheckBox";
-            this.randomizeWindowTitleCheckBox.Size = new System.Drawing.Size(137, 17);
+            this.randomizeWindowTitleCheckBox.Size = new System.Drawing.Size(168, 20);
             this.randomizeWindowTitleCheckBox.TabIndex = 5;
             this.randomizeWindowTitleCheckBox.Text = "Randomize window title";
             this.randomizeWindowTitleCheckBox.UseVisualStyleBackColor = true;
@@ -324,9 +348,10 @@ namespace ReClassNET.Forms
             // runAsAdminCheckBox
             // 
             this.runAsAdminCheckBox.AutoSize = true;
-            this.runAsAdminCheckBox.Location = new System.Drawing.Point(6, 111);
+            this.runAsAdminCheckBox.Location = new System.Drawing.Point(8, 137);
+            this.runAsAdminCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.runAsAdminCheckBox.Name = "runAsAdminCheckBox";
-            this.runAsAdminCheckBox.Size = new System.Drawing.Size(200, 17);
+            this.runAsAdminCheckBox.Size = new System.Drawing.Size(251, 20);
             this.runAsAdminCheckBox.TabIndex = 4;
             this.runAsAdminCheckBox.Text = "Run as administrator (requires restart)";
             this.runAsAdminCheckBox.UseVisualStyleBackColor = true;
@@ -334,9 +359,10 @@ namespace ReClassNET.Forms
             // highlightChangedValuesCheckBox
             // 
             this.highlightChangedValuesCheckBox.AutoSize = true;
-            this.highlightChangedValuesCheckBox.Location = new System.Drawing.Point(6, 88);
+            this.highlightChangedValuesCheckBox.Location = new System.Drawing.Point(8, 108);
+            this.highlightChangedValuesCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.highlightChangedValuesCheckBox.Name = "highlightChangedValuesCheckBox";
-            this.highlightChangedValuesCheckBox.Size = new System.Drawing.Size(148, 17);
+            this.highlightChangedValuesCheckBox.Size = new System.Drawing.Size(184, 20);
             this.highlightChangedValuesCheckBox.TabIndex = 3;
             this.highlightChangedValuesCheckBox.Text = "Highlight Changed Values";
             this.highlightChangedValuesCheckBox.UseVisualStyleBackColor = true;
@@ -344,9 +370,10 @@ namespace ReClassNET.Forms
             // showTextCheckBox
             // 
             this.showTextCheckBox.AutoSize = true;
-            this.showTextCheckBox.Location = new System.Drawing.Point(6, 65);
+            this.showTextCheckBox.Location = new System.Drawing.Point(8, 80);
+            this.showTextCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.showTextCheckBox.Name = "showTextCheckBox";
-            this.showTextCheckBox.Size = new System.Drawing.Size(166, 17);
+            this.showTextCheckBox.Size = new System.Drawing.Size(204, 20);
             this.showTextCheckBox.TabIndex = 2;
             this.showTextCheckBox.Text = "Show Textual Representation";
             this.showTextCheckBox.UseVisualStyleBackColor = true;
@@ -354,9 +381,10 @@ namespace ReClassNET.Forms
             // showNodeOffsetCheckBox
             // 
             this.showNodeOffsetCheckBox.AutoSize = true;
-            this.showNodeOffsetCheckBox.Location = new System.Drawing.Point(6, 42);
+            this.showNodeOffsetCheckBox.Location = new System.Drawing.Point(8, 52);
+            this.showNodeOffsetCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.showNodeOffsetCheckBox.Name = "showNodeOffsetCheckBox";
-            this.showNodeOffsetCheckBox.Size = new System.Drawing.Size(113, 17);
+            this.showNodeOffsetCheckBox.Size = new System.Drawing.Size(136, 20);
             this.showNodeOffsetCheckBox.TabIndex = 1;
             this.showNodeOffsetCheckBox.Text = "Show Node Offset";
             this.showNodeOffsetCheckBox.UseVisualStyleBackColor = true;
@@ -364,9 +392,10 @@ namespace ReClassNET.Forms
             // showNodeAddressCheckBox
             // 
             this.showNodeAddressCheckBox.AutoSize = true;
-            this.showNodeAddressCheckBox.Location = new System.Drawing.Point(6, 19);
+            this.showNodeAddressCheckBox.Location = new System.Drawing.Point(8, 23);
+            this.showNodeAddressCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.showNodeAddressCheckBox.Name = "showNodeAddressCheckBox";
-            this.showNodeAddressCheckBox.Size = new System.Drawing.Size(123, 17);
+            this.showNodeAddressCheckBox.Size = new System.Drawing.Size(153, 20);
             this.showNodeAddressCheckBox.TabIndex = 0;
             this.showNodeAddressCheckBox.Text = "Show Node Address";
             this.showNodeAddressCheckBox.UseVisualStyleBackColor = true;
@@ -374,9 +403,10 @@ namespace ReClassNET.Forms
             // stayOnTopCheckBox
             // 
             this.stayOnTopCheckBox.AutoSize = true;
-            this.stayOnTopCheckBox.Location = new System.Drawing.Point(6, 6);
+            this.stayOnTopCheckBox.Location = new System.Drawing.Point(8, 7);
+            this.stayOnTopCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.stayOnTopCheckBox.Name = "stayOnTopCheckBox";
-            this.stayOnTopCheckBox.Size = new System.Drawing.Size(187, 17);
+            this.stayOnTopCheckBox.Size = new System.Drawing.Size(232, 20);
             this.stayOnTopCheckBox.TabIndex = 1;
             this.stayOnTopCheckBox.Text = "Force ReClass.NET to stay on top";
             this.stayOnTopCheckBox.UseVisualStyleBackColor = true;
@@ -386,10 +416,11 @@ namespace ReClassNET.Forms
             this.colorsSettingTabPage.Controls.Add(this.nodeColorGroupBox);
             this.colorsSettingTabPage.Controls.Add(this.backgroundLabel);
             this.colorsSettingTabPage.Controls.Add(this.backgroundColorBox);
-            this.colorsSettingTabPage.Location = new System.Drawing.Point(4, 22);
+            this.colorsSettingTabPage.Location = new System.Drawing.Point(4, 25);
+            this.colorsSettingTabPage.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.colorsSettingTabPage.Name = "colorsSettingTabPage";
-            this.colorsSettingTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.colorsSettingTabPage.Size = new System.Drawing.Size(554, 329);
+            this.colorsSettingTabPage.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.colorsSettingTabPage.Size = new System.Drawing.Size(741, 408);
             this.colorsSettingTabPage.TabIndex = 1;
             this.colorsSettingTabPage.Text = "Colors";
             this.colorsSettingTabPage.UseVisualStyleBackColor = true;
@@ -422,9 +453,11 @@ namespace ReClassNET.Forms
             this.nodeColorGroupBox.Controls.Add(this.nodeTypeLabel);
             this.nodeColorGroupBox.Controls.Add(this.nodeNameLabel);
             this.nodeColorGroupBox.Controls.Add(this.nodeNameColorBox);
-            this.nodeColorGroupBox.Location = new System.Drawing.Point(9, 43);
+            this.nodeColorGroupBox.Location = new System.Drawing.Point(12, 53);
+            this.nodeColorGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.nodeColorGroupBox.Name = "nodeColorGroupBox";
-            this.nodeColorGroupBox.Size = new System.Drawing.Size(539, 225);
+            this.nodeColorGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.nodeColorGroupBox.Size = new System.Drawing.Size(719, 277);
             this.nodeColorGroupBox.TabIndex = 28;
             this.nodeColorGroupBox.TabStop = false;
             this.nodeColorGroupBox.Text = "Node Colors";
@@ -432,25 +465,28 @@ namespace ReClassNET.Forms
             // nodeValueLabel
             // 
             this.nodeValueLabel.AutoSize = true;
-            this.nodeValueLabel.Location = new System.Drawing.Point(9, 198);
+            this.nodeValueLabel.Location = new System.Drawing.Point(12, 244);
+            this.nodeValueLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodeValueLabel.Name = "nodeValueLabel";
-            this.nodeValueLabel.Size = new System.Drawing.Size(64, 13);
+            this.nodeValueLabel.Size = new System.Drawing.Size(80, 16);
             this.nodeValueLabel.TabIndex = 17;
             this.nodeValueLabel.Text = "Value Color:";
             // 
             // nodePluginLabel
             // 
             this.nodePluginLabel.AutoSize = true;
-            this.nodePluginLabel.Location = new System.Drawing.Point(286, 172);
+            this.nodePluginLabel.Location = new System.Drawing.Point(381, 212);
+            this.nodePluginLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodePluginLabel.Name = "nodePluginLabel";
-            this.nodePluginLabel.Size = new System.Drawing.Size(87, 13);
+            this.nodePluginLabel.Size = new System.Drawing.Size(106, 16);
             this.nodePluginLabel.TabIndex = 27;
             this.nodePluginLabel.Text = "Plugin Info Color:";
             // 
             // nodeHexValueColorBox
             // 
             this.nodeHexValueColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodeHexValueColorBox.Location = new System.Drawing.Point(133, 117);
+            this.nodeHexValueColorBox.Location = new System.Drawing.Point(177, 144);
+            this.nodeHexValueColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodeHexValueColorBox.Name = "nodeHexValueColorBox";
             this.nodeHexValueColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodeHexValueColorBox.TabIndex = 2;
@@ -458,7 +494,8 @@ namespace ReClassNET.Forms
             // nodePluginColorBox
             // 
             this.nodePluginColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodePluginColorBox.Location = new System.Drawing.Point(410, 169);
+            this.nodePluginColorBox.Location = new System.Drawing.Point(547, 208);
+            this.nodePluginColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodePluginColorBox.Name = "nodePluginColorBox";
             this.nodePluginColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodePluginColorBox.TabIndex = 26;
@@ -466,25 +503,28 @@ namespace ReClassNET.Forms
             // nodeHexValueLabel
             // 
             this.nodeHexValueLabel.AutoSize = true;
-            this.nodeHexValueLabel.Location = new System.Drawing.Point(9, 120);
+            this.nodeHexValueLabel.Location = new System.Drawing.Point(12, 148);
+            this.nodeHexValueLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodeHexValueLabel.Name = "nodeHexValueLabel";
-            this.nodeHexValueLabel.Size = new System.Drawing.Size(86, 13);
+            this.nodeHexValueLabel.Size = new System.Drawing.Size(107, 16);
             this.nodeHexValueLabel.TabIndex = 3;
             this.nodeHexValueLabel.Text = "Hex Value Color:";
             // 
             // nodeVTableLabel
             // 
             this.nodeVTableLabel.AutoSize = true;
-            this.nodeVTableLabel.Location = new System.Drawing.Point(286, 94);
+            this.nodeVTableLabel.Location = new System.Drawing.Point(381, 116);
+            this.nodeVTableLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodeVTableLabel.Name = "nodeVTableLabel";
-            this.nodeVTableLabel.Size = new System.Drawing.Size(71, 13);
+            this.nodeVTableLabel.Size = new System.Drawing.Size(90, 16);
             this.nodeVTableLabel.TabIndex = 25;
             this.nodeVTableLabel.Text = "VTable Color:";
             // 
             // nodeOffsetColorBox
             // 
             this.nodeOffsetColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodeOffsetColorBox.Location = new System.Drawing.Point(133, 91);
+            this.nodeOffsetColorBox.Location = new System.Drawing.Point(177, 112);
+            this.nodeOffsetColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodeOffsetColorBox.Name = "nodeOffsetColorBox";
             this.nodeOffsetColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodeOffsetColorBox.TabIndex = 4;
@@ -492,7 +532,8 @@ namespace ReClassNET.Forms
             // nodeVTableColorBox
             // 
             this.nodeVTableColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodeVTableColorBox.Location = new System.Drawing.Point(410, 91);
+            this.nodeVTableColorBox.Location = new System.Drawing.Point(547, 112);
+            this.nodeVTableColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodeVTableColorBox.Name = "nodeVTableColorBox";
             this.nodeVTableColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodeVTableColorBox.TabIndex = 24;
@@ -500,25 +541,28 @@ namespace ReClassNET.Forms
             // nodeOffsetLabel
             // 
             this.nodeOffsetLabel.AutoSize = true;
-            this.nodeOffsetLabel.Location = new System.Drawing.Point(9, 94);
+            this.nodeOffsetLabel.Location = new System.Drawing.Point(12, 116);
+            this.nodeOffsetLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodeOffsetLabel.Name = "nodeOffsetLabel";
-            this.nodeOffsetLabel.Size = new System.Drawing.Size(65, 13);
+            this.nodeOffsetLabel.Size = new System.Drawing.Size(79, 16);
             this.nodeOffsetLabel.TabIndex = 5;
             this.nodeOffsetLabel.Text = "Offset Color:";
             // 
             // nodeTextLabel
             // 
             this.nodeTextLabel.AutoSize = true;
-            this.nodeTextLabel.Location = new System.Drawing.Point(286, 146);
+            this.nodeTextLabel.Location = new System.Drawing.Point(381, 180);
+            this.nodeTextLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodeTextLabel.Name = "nodeTextLabel";
-            this.nodeTextLabel.Size = new System.Drawing.Size(58, 13);
+            this.nodeTextLabel.Size = new System.Drawing.Size(71, 16);
             this.nodeTextLabel.TabIndex = 23;
             this.nodeTextLabel.Text = "Text Color:";
             // 
             // nodeAddressColorBox
             // 
             this.nodeAddressColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodeAddressColorBox.Location = new System.Drawing.Point(133, 65);
+            this.nodeAddressColorBox.Location = new System.Drawing.Point(177, 80);
+            this.nodeAddressColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodeAddressColorBox.Name = "nodeAddressColorBox";
             this.nodeAddressColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodeAddressColorBox.TabIndex = 6;
@@ -526,7 +570,8 @@ namespace ReClassNET.Forms
             // nodeTextColorBox
             // 
             this.nodeTextColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodeTextColorBox.Location = new System.Drawing.Point(410, 143);
+            this.nodeTextColorBox.Location = new System.Drawing.Point(547, 176);
+            this.nodeTextColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodeTextColorBox.Name = "nodeTextColorBox";
             this.nodeTextColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodeTextColorBox.TabIndex = 22;
@@ -534,25 +579,28 @@ namespace ReClassNET.Forms
             // nodeAddressLabel
             // 
             this.nodeAddressLabel.AutoSize = true;
-            this.nodeAddressLabel.Location = new System.Drawing.Point(9, 68);
+            this.nodeAddressLabel.Location = new System.Drawing.Point(12, 84);
+            this.nodeAddressLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodeAddressLabel.Name = "nodeAddressLabel";
-            this.nodeAddressLabel.Size = new System.Drawing.Size(75, 13);
+            this.nodeAddressLabel.Size = new System.Drawing.Size(96, 16);
             this.nodeAddressLabel.TabIndex = 7;
             this.nodeAddressLabel.Text = "Address Color:";
             // 
             // nodeCommentLabel
             // 
             this.nodeCommentLabel.AutoSize = true;
-            this.nodeCommentLabel.Location = new System.Drawing.Point(286, 120);
+            this.nodeCommentLabel.Location = new System.Drawing.Point(381, 148);
+            this.nodeCommentLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodeCommentLabel.Name = "nodeCommentLabel";
-            this.nodeCommentLabel.Size = new System.Drawing.Size(81, 13);
+            this.nodeCommentLabel.Size = new System.Drawing.Size(102, 16);
             this.nodeCommentLabel.TabIndex = 21;
             this.nodeCommentLabel.Text = "Comment Color:";
             // 
             // nodeHiddenColorBox
             // 
             this.nodeHiddenColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodeHiddenColorBox.Location = new System.Drawing.Point(410, 18);
+            this.nodeHiddenColorBox.Location = new System.Drawing.Point(547, 22);
+            this.nodeHiddenColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodeHiddenColorBox.Name = "nodeHiddenColorBox";
             this.nodeHiddenColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodeHiddenColorBox.TabIndex = 8;
@@ -560,7 +608,8 @@ namespace ReClassNET.Forms
             // nodeCommentColorBox
             // 
             this.nodeCommentColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodeCommentColorBox.Location = new System.Drawing.Point(410, 117);
+            this.nodeCommentColorBox.Location = new System.Drawing.Point(547, 144);
+            this.nodeCommentColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodeCommentColorBox.Name = "nodeCommentColorBox";
             this.nodeCommentColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodeCommentColorBox.TabIndex = 20;
@@ -568,25 +617,28 @@ namespace ReClassNET.Forms
             // nodeHiddenLabel
             // 
             this.nodeHiddenLabel.AutoSize = true;
-            this.nodeHiddenLabel.Location = new System.Drawing.Point(286, 21);
+            this.nodeHiddenLabel.Location = new System.Drawing.Point(381, 26);
+            this.nodeHiddenLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodeHiddenLabel.Name = "nodeHiddenLabel";
-            this.nodeHiddenLabel.Size = new System.Drawing.Size(71, 13);
+            this.nodeHiddenLabel.Size = new System.Drawing.Size(89, 16);
             this.nodeHiddenLabel.TabIndex = 9;
             this.nodeHiddenLabel.Text = "Hidden Color:";
             // 
             // nodeIndexLabel
             // 
             this.nodeIndexLabel.AutoSize = true;
-            this.nodeIndexLabel.Location = new System.Drawing.Point(286, 68);
+            this.nodeIndexLabel.Location = new System.Drawing.Point(381, 84);
+            this.nodeIndexLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodeIndexLabel.Name = "nodeIndexLabel";
-            this.nodeIndexLabel.Size = new System.Drawing.Size(63, 13);
+            this.nodeIndexLabel.Size = new System.Drawing.Size(77, 16);
             this.nodeIndexLabel.TabIndex = 19;
             this.nodeIndexLabel.Text = "Index Color:";
             // 
             // nodeSelectedColorBox
             // 
             this.nodeSelectedColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodeSelectedColorBox.Location = new System.Drawing.Point(133, 18);
+            this.nodeSelectedColorBox.Location = new System.Drawing.Point(177, 22);
+            this.nodeSelectedColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodeSelectedColorBox.Name = "nodeSelectedColorBox";
             this.nodeSelectedColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodeSelectedColorBox.TabIndex = 10;
@@ -594,7 +646,8 @@ namespace ReClassNET.Forms
             // nodeIndexColorBox
             // 
             this.nodeIndexColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodeIndexColorBox.Location = new System.Drawing.Point(410, 65);
+            this.nodeIndexColorBox.Location = new System.Drawing.Point(547, 80);
+            this.nodeIndexColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodeIndexColorBox.Name = "nodeIndexColorBox";
             this.nodeIndexColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodeIndexColorBox.TabIndex = 18;
@@ -602,16 +655,18 @@ namespace ReClassNET.Forms
             // nodeSelectedLabel
             // 
             this.nodeSelectedLabel.AutoSize = true;
-            this.nodeSelectedLabel.Location = new System.Drawing.Point(9, 21);
+            this.nodeSelectedLabel.Location = new System.Drawing.Point(12, 26);
+            this.nodeSelectedLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodeSelectedLabel.Name = "nodeSelectedLabel";
-            this.nodeSelectedLabel.Size = new System.Drawing.Size(79, 13);
+            this.nodeSelectedLabel.Size = new System.Drawing.Size(99, 16);
             this.nodeSelectedLabel.TabIndex = 11;
             this.nodeSelectedLabel.Text = "Selected Color:";
             // 
             // nodeTypeColorBox
             // 
             this.nodeTypeColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodeTypeColorBox.Location = new System.Drawing.Point(133, 143);
+            this.nodeTypeColorBox.Location = new System.Drawing.Point(177, 176);
+            this.nodeTypeColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodeTypeColorBox.Name = "nodeTypeColorBox";
             this.nodeTypeColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodeTypeColorBox.TabIndex = 12;
@@ -619,7 +674,8 @@ namespace ReClassNET.Forms
             // nodeValueColorBox
             // 
             this.nodeValueColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodeValueColorBox.Location = new System.Drawing.Point(133, 195);
+            this.nodeValueColorBox.Location = new System.Drawing.Point(177, 240);
+            this.nodeValueColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodeValueColorBox.Name = "nodeValueColorBox";
             this.nodeValueColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodeValueColorBox.TabIndex = 16;
@@ -627,25 +683,28 @@ namespace ReClassNET.Forms
             // nodeTypeLabel
             // 
             this.nodeTypeLabel.AutoSize = true;
-            this.nodeTypeLabel.Location = new System.Drawing.Point(9, 146);
+            this.nodeTypeLabel.Location = new System.Drawing.Point(12, 180);
+            this.nodeTypeLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodeTypeLabel.Name = "nodeTypeLabel";
-            this.nodeTypeLabel.Size = new System.Drawing.Size(61, 13);
+            this.nodeTypeLabel.Size = new System.Drawing.Size(77, 16);
             this.nodeTypeLabel.TabIndex = 13;
             this.nodeTypeLabel.Text = "Type Color:";
             // 
             // nodeNameLabel
             // 
             this.nodeNameLabel.AutoSize = true;
-            this.nodeNameLabel.Location = new System.Drawing.Point(9, 172);
+            this.nodeNameLabel.Location = new System.Drawing.Point(12, 212);
+            this.nodeNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nodeNameLabel.Name = "nodeNameLabel";
-            this.nodeNameLabel.Size = new System.Drawing.Size(65, 13);
+            this.nodeNameLabel.Size = new System.Drawing.Size(82, 16);
             this.nodeNameLabel.TabIndex = 15;
             this.nodeNameLabel.Text = "Name Color:";
             // 
             // nodeNameColorBox
             // 
             this.nodeNameColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.nodeNameColorBox.Location = new System.Drawing.Point(133, 169);
+            this.nodeNameColorBox.Location = new System.Drawing.Point(177, 208);
+            this.nodeNameColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.nodeNameColorBox.Name = "nodeNameColorBox";
             this.nodeNameColorBox.Size = new System.Drawing.Size(123, 20);
             this.nodeNameColorBox.TabIndex = 14;
@@ -653,16 +712,18 @@ namespace ReClassNET.Forms
             // backgroundLabel
             // 
             this.backgroundLabel.AutoSize = true;
-            this.backgroundLabel.Location = new System.Drawing.Point(6, 14);
+            this.backgroundLabel.Location = new System.Drawing.Point(8, 17);
+            this.backgroundLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.backgroundLabel.Name = "backgroundLabel";
-            this.backgroundLabel.Size = new System.Drawing.Size(161, 13);
+            this.backgroundLabel.Size = new System.Drawing.Size(202, 16);
             this.backgroundLabel.TabIndex = 1;
             this.backgroundLabel.Text = "Memory View Background Color:";
             // 
             // backgroundColorBox
             // 
             this.backgroundColorBox.Color = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.backgroundColorBox.Location = new System.Drawing.Point(175, 11);
+            this.backgroundColorBox.Location = new System.Drawing.Point(233, 14);
+            this.backgroundColorBox.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.backgroundColorBox.Name = "backgroundColorBox";
             this.backgroundColorBox.Size = new System.Drawing.Size(123, 20);
             this.backgroundColorBox.TabIndex = 0;
@@ -716,373 +777,437 @@ namespace ReClassNET.Forms
             this.typeDefinitionsSettingsTabPage.Controls.Add(this.int16TypeTextBox);
             this.typeDefinitionsSettingsTabPage.Controls.Add(this.int8SettingsLabel);
             this.typeDefinitionsSettingsTabPage.Controls.Add(this.int8TypeTextBox);
-            this.typeDefinitionsSettingsTabPage.Location = new System.Drawing.Point(4, 22);
+            this.typeDefinitionsSettingsTabPage.Location = new System.Drawing.Point(4, 25);
+            this.typeDefinitionsSettingsTabPage.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.typeDefinitionsSettingsTabPage.Name = "typeDefinitionsSettingsTabPage";
-            this.typeDefinitionsSettingsTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.typeDefinitionsSettingsTabPage.Size = new System.Drawing.Size(554, 329);
+            this.typeDefinitionsSettingsTabPage.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.typeDefinitionsSettingsTabPage.Size = new System.Drawing.Size(741, 408);
             this.typeDefinitionsSettingsTabPage.TabIndex = 2;
             this.typeDefinitionsSettingsTabPage.Text = "Type Definitions";
             this.typeDefinitionsSettingsTabPage.UseVisualStyleBackColor = true;
             // 
+            // utf32TextSettingsLabel
+            // 
+            this.utf32TextSettingsLabel.AutoSize = true;
+            this.utf32TextSettingsLabel.Location = new System.Drawing.Point(339, 287);
+            this.utf32TextSettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.utf32TextSettingsLabel.Name = "utf32TextSettingsLabel";
+            this.utf32TextSettingsLabel.Size = new System.Drawing.Size(51, 16);
+            this.utf32TextSettingsLabel.TabIndex = 52;
+            this.utf32TextSettingsLabel.Text = "UTF32:";
+            // 
+            // utf32TextTypeTextBox
+            // 
+            this.utf32TextTypeTextBox.Location = new System.Drawing.Point(461, 283);
+            this.utf32TextTypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.utf32TextTypeTextBox.Name = "utf32TextTypeTextBox";
+            this.utf32TextTypeTextBox.Size = new System.Drawing.Size(159, 22);
+            this.utf32TextTypeTextBox.TabIndex = 51;
+            // 
             // nuintSettingsLabel
             // 
             this.nuintSettingsLabel.AutoSize = true;
-            this.nuintSettingsLabel.Location = new System.Drawing.Point(6, 233);
+            this.nuintSettingsLabel.Location = new System.Drawing.Point(8, 287);
+            this.nuintSettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nuintSettingsLabel.Name = "nuintSettingsLabel";
-            this.nuintSettingsLabel.Size = new System.Drawing.Size(38, 13);
+            this.nuintSettingsLabel.Size = new System.Drawing.Size(43, 16);
             this.nuintSettingsLabel.TabIndex = 50;
             this.nuintSettingsLabel.Text = "NUInt:";
             // 
             // nuintTypeTextBox
             // 
-            this.nuintTypeTextBox.Location = new System.Drawing.Point(98, 230);
+            this.nuintTypeTextBox.Location = new System.Drawing.Point(131, 283);
+            this.nuintTypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.nuintTypeTextBox.Name = "nuintTypeTextBox";
-            this.nuintTypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.nuintTypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.nuintTypeTextBox.TabIndex = 49;
             // 
             // nintSettingsLabel
             // 
             this.nintSettingsLabel.AutoSize = true;
-            this.nintSettingsLabel.Location = new System.Drawing.Point(6, 123);
+            this.nintSettingsLabel.Location = new System.Drawing.Point(8, 151);
+            this.nintSettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.nintSettingsLabel.Name = "nintSettingsLabel";
-            this.nintSettingsLabel.Size = new System.Drawing.Size(30, 13);
+            this.nintSettingsLabel.Size = new System.Drawing.Size(33, 16);
             this.nintSettingsLabel.TabIndex = 48;
             this.nintSettingsLabel.Text = "NInt:";
             // 
             // nintTypeTextBox
             // 
-            this.nintTypeTextBox.Location = new System.Drawing.Point(98, 120);
+            this.nintTypeTextBox.Location = new System.Drawing.Point(131, 148);
+            this.nintTypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.nintTypeTextBox.Name = "nintTypeTextBox";
-            this.nintTypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.nintTypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.nintTypeTextBox.TabIndex = 47;
             // 
             // boolSettingsLabel
             // 
             this.boolSettingsLabel.AutoSize = true;
-            this.boolSettingsLabel.Location = new System.Drawing.Point(254, 35);
+            this.boolSettingsLabel.Location = new System.Drawing.Point(339, 43);
+            this.boolSettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.boolSettingsLabel.Name = "boolSettingsLabel";
-            this.boolSettingsLabel.Size = new System.Drawing.Size(31, 13);
+            this.boolSettingsLabel.Size = new System.Drawing.Size(38, 16);
             this.boolSettingsLabel.TabIndex = 46;
             this.boolSettingsLabel.Text = "Bool:";
             // 
             // boolTypeTextBox
             // 
-            this.boolTypeTextBox.Location = new System.Drawing.Point(346, 32);
+            this.boolTypeTextBox.Location = new System.Drawing.Point(461, 39);
+            this.boolTypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.boolTypeTextBox.Name = "boolTypeTextBox";
-            this.boolTypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.boolTypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.boolTypeTextBox.TabIndex = 45;
             // 
             // generatorInfoLabel
             // 
             this.generatorInfoLabel.AutoSize = true;
-            this.generatorInfoLabel.Location = new System.Drawing.Point(6, 6);
+            this.generatorInfoLabel.Location = new System.Drawing.Point(8, 7);
+            this.generatorInfoLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.generatorInfoLabel.Name = "generatorInfoLabel";
-            this.generatorInfoLabel.Size = new System.Drawing.Size(236, 13);
+            this.generatorInfoLabel.Size = new System.Drawing.Size(293, 16);
             this.generatorInfoLabel.TabIndex = 44;
             this.generatorInfoLabel.Text = "These types are used to generate the C++ code:";
             // 
             // functionPtrSettingsLabel
             // 
             this.functionPtrSettingsLabel.AutoSize = true;
-            this.functionPtrSettingsLabel.Location = new System.Drawing.Point(254, 255);
+            this.functionPtrSettingsLabel.Location = new System.Drawing.Point(339, 314);
+            this.functionPtrSettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.functionPtrSettingsLabel.Name = "functionPtrSettingsLabel";
-            this.functionPtrSettingsLabel.Size = new System.Drawing.Size(87, 13);
+            this.functionPtrSettingsLabel.Size = new System.Drawing.Size(105, 16);
             this.functionPtrSettingsLabel.TabIndex = 43;
             this.functionPtrSettingsLabel.Text = "Function Pointer:";
             // 
             // functionPtrTypeTextBox
             // 
-            this.functionPtrTypeTextBox.Location = new System.Drawing.Point(346, 252);
+            this.functionPtrTypeTextBox.Location = new System.Drawing.Point(461, 310);
+            this.functionPtrTypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.functionPtrTypeTextBox.Name = "functionPtrTypeTextBox";
-            this.functionPtrTypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.functionPtrTypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.functionPtrTypeTextBox.TabIndex = 42;
             // 
             // utf16TextSettingsLabel
             // 
             this.utf16TextSettingsLabel.AutoSize = true;
-            this.utf16TextSettingsLabel.Location = new System.Drawing.Point(254, 211);
+            this.utf16TextSettingsLabel.Location = new System.Drawing.Point(339, 260);
+            this.utf16TextSettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.utf16TextSettingsLabel.Name = "utf16TextSettingsLabel";
-            this.utf16TextSettingsLabel.Size = new System.Drawing.Size(43, 13);
+            this.utf16TextSettingsLabel.Size = new System.Drawing.Size(51, 16);
             this.utf16TextSettingsLabel.TabIndex = 39;
             this.utf16TextSettingsLabel.Text = "UTF16:";
             // 
             // utf16TextTypeTextBox
             // 
-            this.utf16TextTypeTextBox.Location = new System.Drawing.Point(346, 208);
+            this.utf16TextTypeTextBox.Location = new System.Drawing.Point(461, 256);
+            this.utf16TextTypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.utf16TextTypeTextBox.Name = "utf16TextTypeTextBox";
-            this.utf16TextTypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.utf16TextTypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.utf16TextTypeTextBox.TabIndex = 38;
             // 
             // utf8TextSettingsLabel
             // 
             this.utf8TextSettingsLabel.AutoSize = true;
-            this.utf8TextSettingsLabel.Location = new System.Drawing.Point(254, 189);
+            this.utf8TextSettingsLabel.Location = new System.Drawing.Point(339, 233);
+            this.utf8TextSettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.utf8TextSettingsLabel.Name = "utf8TextSettingsLabel";
-            this.utf8TextSettingsLabel.Size = new System.Drawing.Size(37, 13);
+            this.utf8TextSettingsLabel.Size = new System.Drawing.Size(44, 16);
             this.utf8TextSettingsLabel.TabIndex = 35;
             this.utf8TextSettingsLabel.Text = "UTF8:";
             // 
             // utf8TextTypeTextBox
             // 
-            this.utf8TextTypeTextBox.Location = new System.Drawing.Point(346, 186);
+            this.utf8TextTypeTextBox.Location = new System.Drawing.Point(461, 229);
+            this.utf8TextTypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.utf8TextTypeTextBox.Name = "utf8TextTypeTextBox";
-            this.utf8TextTypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.utf8TextTypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.utf8TextTypeTextBox.TabIndex = 34;
             // 
             // matrix3x3SettingsLabel
             // 
             this.matrix3x3SettingsLabel.AutoSize = true;
-            this.matrix3x3SettingsLabel.Location = new System.Drawing.Point(254, 123);
+            this.matrix3x3SettingsLabel.Location = new System.Drawing.Point(339, 151);
+            this.matrix3x3SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.matrix3x3SettingsLabel.Name = "matrix3x3SettingsLabel";
-            this.matrix3x3SettingsLabel.Size = new System.Drawing.Size(64, 13);
+            this.matrix3x3SettingsLabel.Size = new System.Drawing.Size(76, 16);
             this.matrix3x3SettingsLabel.TabIndex = 33;
             this.matrix3x3SettingsLabel.Text = "Matrix (3x3):";
             // 
             // matrix3x3TypeTextBox
             // 
-            this.matrix3x3TypeTextBox.Location = new System.Drawing.Point(346, 120);
+            this.matrix3x3TypeTextBox.Location = new System.Drawing.Point(461, 148);
+            this.matrix3x3TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.matrix3x3TypeTextBox.Name = "matrix3x3TypeTextBox";
-            this.matrix3x3TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.matrix3x3TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.matrix3x3TypeTextBox.TabIndex = 32;
             // 
             // matrix3x4SettingsLabel
             // 
             this.matrix3x4SettingsLabel.AutoSize = true;
-            this.matrix3x4SettingsLabel.Location = new System.Drawing.Point(254, 145);
+            this.matrix3x4SettingsLabel.Location = new System.Drawing.Point(339, 178);
+            this.matrix3x4SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.matrix3x4SettingsLabel.Name = "matrix3x4SettingsLabel";
-            this.matrix3x4SettingsLabel.Size = new System.Drawing.Size(64, 13);
+            this.matrix3x4SettingsLabel.Size = new System.Drawing.Size(76, 16);
             this.matrix3x4SettingsLabel.TabIndex = 31;
             this.matrix3x4SettingsLabel.Text = "Matrix (3x4):";
             // 
             // matrix3x4TypeTextBox
             // 
-            this.matrix3x4TypeTextBox.Location = new System.Drawing.Point(346, 142);
+            this.matrix3x4TypeTextBox.Location = new System.Drawing.Point(461, 175);
+            this.matrix3x4TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.matrix3x4TypeTextBox.Name = "matrix3x4TypeTextBox";
-            this.matrix3x4TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.matrix3x4TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.matrix3x4TypeTextBox.TabIndex = 30;
             // 
             // matrix4x4SettingsLabel
             // 
             this.matrix4x4SettingsLabel.AutoSize = true;
-            this.matrix4x4SettingsLabel.Location = new System.Drawing.Point(254, 167);
+            this.matrix4x4SettingsLabel.Location = new System.Drawing.Point(339, 206);
+            this.matrix4x4SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.matrix4x4SettingsLabel.Name = "matrix4x4SettingsLabel";
-            this.matrix4x4SettingsLabel.Size = new System.Drawing.Size(64, 13);
+            this.matrix4x4SettingsLabel.Size = new System.Drawing.Size(76, 16);
             this.matrix4x4SettingsLabel.TabIndex = 29;
             this.matrix4x4SettingsLabel.Text = "Matrix (4x4):";
             // 
             // matrix4x4TypeTextBox
             // 
-            this.matrix4x4TypeTextBox.Location = new System.Drawing.Point(346, 164);
+            this.matrix4x4TypeTextBox.Location = new System.Drawing.Point(461, 202);
+            this.matrix4x4TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.matrix4x4TypeTextBox.Name = "matrix4x4TypeTextBox";
-            this.matrix4x4TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.matrix4x4TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.matrix4x4TypeTextBox.TabIndex = 28;
             // 
             // vector2SettingsLabel
             // 
             this.vector2SettingsLabel.AutoSize = true;
-            this.vector2SettingsLabel.Location = new System.Drawing.Point(254, 57);
+            this.vector2SettingsLabel.Location = new System.Drawing.Point(339, 70);
+            this.vector2SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.vector2SettingsLabel.Name = "vector2SettingsLabel";
-            this.vector2SettingsLabel.Size = new System.Drawing.Size(47, 13);
+            this.vector2SettingsLabel.Size = new System.Drawing.Size(56, 16);
             this.vector2SettingsLabel.TabIndex = 27;
             this.vector2SettingsLabel.Text = "Vector2:";
             // 
             // vector2TypeTextBox
             // 
-            this.vector2TypeTextBox.Location = new System.Drawing.Point(346, 54);
+            this.vector2TypeTextBox.Location = new System.Drawing.Point(461, 66);
+            this.vector2TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.vector2TypeTextBox.Name = "vector2TypeTextBox";
-            this.vector2TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.vector2TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.vector2TypeTextBox.TabIndex = 26;
             // 
             // vector3SettingsLabel
             // 
             this.vector3SettingsLabel.AutoSize = true;
-            this.vector3SettingsLabel.Location = new System.Drawing.Point(254, 79);
+            this.vector3SettingsLabel.Location = new System.Drawing.Point(339, 97);
+            this.vector3SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.vector3SettingsLabel.Name = "vector3SettingsLabel";
-            this.vector3SettingsLabel.Size = new System.Drawing.Size(47, 13);
+            this.vector3SettingsLabel.Size = new System.Drawing.Size(56, 16);
             this.vector3SettingsLabel.TabIndex = 25;
             this.vector3SettingsLabel.Text = "Vector3:";
             // 
             // vector3TypeTextBox
             // 
-            this.vector3TypeTextBox.Location = new System.Drawing.Point(346, 76);
+            this.vector3TypeTextBox.Location = new System.Drawing.Point(461, 94);
+            this.vector3TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.vector3TypeTextBox.Name = "vector3TypeTextBox";
-            this.vector3TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.vector3TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.vector3TypeTextBox.TabIndex = 24;
             // 
             // vector4SettingsLabel
             // 
             this.vector4SettingsLabel.AutoSize = true;
-            this.vector4SettingsLabel.Location = new System.Drawing.Point(254, 101);
+            this.vector4SettingsLabel.Location = new System.Drawing.Point(339, 124);
+            this.vector4SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.vector4SettingsLabel.Name = "vector4SettingsLabel";
-            this.vector4SettingsLabel.Size = new System.Drawing.Size(47, 13);
+            this.vector4SettingsLabel.Size = new System.Drawing.Size(56, 16);
             this.vector4SettingsLabel.TabIndex = 23;
             this.vector4SettingsLabel.Text = "Vector4:";
             // 
             // vector4TypeTextBox
             // 
-            this.vector4TypeTextBox.Location = new System.Drawing.Point(346, 98);
+            this.vector4TypeTextBox.Location = new System.Drawing.Point(461, 121);
+            this.vector4TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.vector4TypeTextBox.Name = "vector4TypeTextBox";
-            this.vector4TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.vector4TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.vector4TypeTextBox.TabIndex = 22;
             // 
             // doubleSettingsLabel
             // 
             this.doubleSettingsLabel.AutoSize = true;
-            this.doubleSettingsLabel.Location = new System.Drawing.Point(6, 277);
+            this.doubleSettingsLabel.Location = new System.Drawing.Point(8, 341);
+            this.doubleSettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.doubleSettingsLabel.Name = "doubleSettingsLabel";
-            this.doubleSettingsLabel.Size = new System.Drawing.Size(44, 13);
+            this.doubleSettingsLabel.Size = new System.Drawing.Size(54, 16);
             this.doubleSettingsLabel.TabIndex = 21;
             this.doubleSettingsLabel.Text = "Double:";
             // 
             // doubleTypeTextBox
             // 
-            this.doubleTypeTextBox.Location = new System.Drawing.Point(98, 274);
+            this.doubleTypeTextBox.Location = new System.Drawing.Point(131, 337);
+            this.doubleTypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.doubleTypeTextBox.Name = "doubleTypeTextBox";
-            this.doubleTypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.doubleTypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.doubleTypeTextBox.TabIndex = 20;
             // 
             // floatSettingsLabel
             // 
             this.floatSettingsLabel.AutoSize = true;
-            this.floatSettingsLabel.Location = new System.Drawing.Point(6, 255);
+            this.floatSettingsLabel.Location = new System.Drawing.Point(8, 314);
+            this.floatSettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.floatSettingsLabel.Name = "floatSettingsLabel";
-            this.floatSettingsLabel.Size = new System.Drawing.Size(33, 13);
+            this.floatSettingsLabel.Size = new System.Drawing.Size(40, 16);
             this.floatSettingsLabel.TabIndex = 19;
             this.floatSettingsLabel.Text = "Float:";
             // 
             // floatTypeTextBox
             // 
-            this.floatTypeTextBox.Location = new System.Drawing.Point(98, 252);
+            this.floatTypeTextBox.Location = new System.Drawing.Point(131, 310);
+            this.floatTypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.floatTypeTextBox.Name = "floatTypeTextBox";
-            this.floatTypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.floatTypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.floatTypeTextBox.TabIndex = 18;
             // 
             // uint64SettingsLabel
             // 
             this.uint64SettingsLabel.AutoSize = true;
-            this.uint64SettingsLabel.Location = new System.Drawing.Point(6, 211);
+            this.uint64SettingsLabel.Location = new System.Drawing.Point(8, 260);
+            this.uint64SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.uint64SettingsLabel.Name = "uint64SettingsLabel";
-            this.uint64SettingsLabel.Size = new System.Drawing.Size(42, 13);
+            this.uint64SettingsLabel.Size = new System.Drawing.Size(47, 16);
             this.uint64SettingsLabel.TabIndex = 17;
             this.uint64SettingsLabel.Text = "UInt64:";
             // 
             // uint64TypeTextBox
             // 
-            this.uint64TypeTextBox.Location = new System.Drawing.Point(98, 208);
+            this.uint64TypeTextBox.Location = new System.Drawing.Point(131, 256);
+            this.uint64TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.uint64TypeTextBox.Name = "uint64TypeTextBox";
-            this.uint64TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.uint64TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.uint64TypeTextBox.TabIndex = 16;
             // 
             // uint32SettingsLabel
             // 
             this.uint32SettingsLabel.AutoSize = true;
-            this.uint32SettingsLabel.Location = new System.Drawing.Point(6, 189);
+            this.uint32SettingsLabel.Location = new System.Drawing.Point(8, 233);
+            this.uint32SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.uint32SettingsLabel.Name = "uint32SettingsLabel";
-            this.uint32SettingsLabel.Size = new System.Drawing.Size(42, 13);
+            this.uint32SettingsLabel.Size = new System.Drawing.Size(47, 16);
             this.uint32SettingsLabel.TabIndex = 15;
             this.uint32SettingsLabel.Text = "UInt32:";
             // 
             // uint32TypeTextBox
             // 
-            this.uint32TypeTextBox.Location = new System.Drawing.Point(98, 186);
+            this.uint32TypeTextBox.Location = new System.Drawing.Point(131, 229);
+            this.uint32TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.uint32TypeTextBox.Name = "uint32TypeTextBox";
-            this.uint32TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.uint32TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.uint32TypeTextBox.TabIndex = 14;
             // 
             // uint16SettingsLabel
             // 
             this.uint16SettingsLabel.AutoSize = true;
-            this.uint16SettingsLabel.Location = new System.Drawing.Point(6, 167);
+            this.uint16SettingsLabel.Location = new System.Drawing.Point(8, 206);
+            this.uint16SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.uint16SettingsLabel.Name = "uint16SettingsLabel";
-            this.uint16SettingsLabel.Size = new System.Drawing.Size(42, 13);
+            this.uint16SettingsLabel.Size = new System.Drawing.Size(47, 16);
             this.uint16SettingsLabel.TabIndex = 13;
             this.uint16SettingsLabel.Text = "UInt16:";
             // 
             // uint16TypeTextBox
             // 
-            this.uint16TypeTextBox.Location = new System.Drawing.Point(98, 164);
+            this.uint16TypeTextBox.Location = new System.Drawing.Point(131, 202);
+            this.uint16TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.uint16TypeTextBox.Name = "uint16TypeTextBox";
-            this.uint16TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.uint16TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.uint16TypeTextBox.TabIndex = 12;
             // 
             // uint8SettingsLabel
             // 
             this.uint8SettingsLabel.AutoSize = true;
-            this.uint8SettingsLabel.Location = new System.Drawing.Point(6, 145);
+            this.uint8SettingsLabel.Location = new System.Drawing.Point(8, 178);
+            this.uint8SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.uint8SettingsLabel.Name = "uint8SettingsLabel";
-            this.uint8SettingsLabel.Size = new System.Drawing.Size(36, 13);
+            this.uint8SettingsLabel.Size = new System.Drawing.Size(40, 16);
             this.uint8SettingsLabel.TabIndex = 11;
             this.uint8SettingsLabel.Text = "UInt8:";
             // 
             // uint8TypeTextBox
             // 
-            this.uint8TypeTextBox.Location = new System.Drawing.Point(98, 142);
+            this.uint8TypeTextBox.Location = new System.Drawing.Point(131, 175);
+            this.uint8TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.uint8TypeTextBox.Name = "uint8TypeTextBox";
-            this.uint8TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.uint8TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.uint8TypeTextBox.TabIndex = 10;
             // 
             // int64SettingsLabel
             // 
             this.int64SettingsLabel.AutoSize = true;
-            this.int64SettingsLabel.Location = new System.Drawing.Point(6, 101);
+            this.int64SettingsLabel.Location = new System.Drawing.Point(8, 124);
+            this.int64SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.int64SettingsLabel.Name = "int64SettingsLabel";
-            this.int64SettingsLabel.Size = new System.Drawing.Size(34, 13);
+            this.int64SettingsLabel.Size = new System.Drawing.Size(37, 16);
             this.int64SettingsLabel.TabIndex = 9;
             this.int64SettingsLabel.Text = "Int64:";
             // 
             // int64TypeTextBox
             // 
-            this.int64TypeTextBox.Location = new System.Drawing.Point(98, 98);
+            this.int64TypeTextBox.Location = new System.Drawing.Point(131, 121);
+            this.int64TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.int64TypeTextBox.Name = "int64TypeTextBox";
-            this.int64TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.int64TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.int64TypeTextBox.TabIndex = 8;
             // 
             // int32SettingsLabel
             // 
             this.int32SettingsLabel.AutoSize = true;
-            this.int32SettingsLabel.Location = new System.Drawing.Point(6, 79);
+            this.int32SettingsLabel.Location = new System.Drawing.Point(8, 97);
+            this.int32SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.int32SettingsLabel.Name = "int32SettingsLabel";
-            this.int32SettingsLabel.Size = new System.Drawing.Size(34, 13);
+            this.int32SettingsLabel.Size = new System.Drawing.Size(37, 16);
             this.int32SettingsLabel.TabIndex = 7;
             this.int32SettingsLabel.Text = "Int32:";
             // 
             // int32TypeTextBox
             // 
-            this.int32TypeTextBox.Location = new System.Drawing.Point(98, 76);
+            this.int32TypeTextBox.Location = new System.Drawing.Point(131, 94);
+            this.int32TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.int32TypeTextBox.Name = "int32TypeTextBox";
-            this.int32TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.int32TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.int32TypeTextBox.TabIndex = 6;
             // 
             // int16SettingsLabel
             // 
             this.int16SettingsLabel.AutoSize = true;
-            this.int16SettingsLabel.Location = new System.Drawing.Point(6, 57);
+            this.int16SettingsLabel.Location = new System.Drawing.Point(8, 70);
+            this.int16SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.int16SettingsLabel.Name = "int16SettingsLabel";
-            this.int16SettingsLabel.Size = new System.Drawing.Size(34, 13);
+            this.int16SettingsLabel.Size = new System.Drawing.Size(37, 16);
             this.int16SettingsLabel.TabIndex = 5;
             this.int16SettingsLabel.Text = "Int16:";
             // 
             // int16TypeTextBox
             // 
-            this.int16TypeTextBox.Location = new System.Drawing.Point(98, 54);
+            this.int16TypeTextBox.Location = new System.Drawing.Point(131, 66);
+            this.int16TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.int16TypeTextBox.Name = "int16TypeTextBox";
-            this.int16TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.int16TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.int16TypeTextBox.TabIndex = 4;
             // 
             // int8SettingsLabel
             // 
             this.int8SettingsLabel.AutoSize = true;
-            this.int8SettingsLabel.Location = new System.Drawing.Point(6, 35);
+            this.int8SettingsLabel.Location = new System.Drawing.Point(8, 43);
+            this.int8SettingsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.int8SettingsLabel.Name = "int8SettingsLabel";
-            this.int8SettingsLabel.Size = new System.Drawing.Size(28, 13);
+            this.int8SettingsLabel.Size = new System.Drawing.Size(30, 16);
             this.int8SettingsLabel.TabIndex = 3;
             this.int8SettingsLabel.Text = "Int8:";
             // 
             // int8TypeTextBox
             // 
-            this.int8TypeTextBox.Location = new System.Drawing.Point(98, 32);
+            this.int8TypeTextBox.Location = new System.Drawing.Point(131, 39);
+            this.int8TypeTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.int8TypeTextBox.Name = "int8TypeTextBox";
-            this.int8TypeTextBox.Size = new System.Drawing.Size(120, 20);
+            this.int8TypeTextBox.Size = new System.Drawing.Size(159, 22);
             this.int8TypeTextBox.TabIndex = 2;
             // 
             // bannerBox
@@ -1090,36 +1215,53 @@ namespace ReClassNET.Forms
             this.bannerBox.Dock = System.Windows.Forms.DockStyle.Top;
             this.bannerBox.Icon = global::ReClassNET.Properties.Resources.B32x32_Cogs;
             this.bannerBox.Location = new System.Drawing.Point(0, 0);
+            this.bannerBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.bannerBox.Name = "bannerBox";
-            this.bannerBox.Size = new System.Drawing.Size(586, 48);
+            this.bannerBox.Size = new System.Drawing.Size(781, 48);
             this.bannerBox.TabIndex = 2;
             this.bannerBox.Text = "Configure the global settings.";
             this.bannerBox.Title = "Settings";
             // 
-            // utf32TextSettingsLabel
+            // projectSettingTabPage
             // 
-            this.utf32TextSettingsLabel.AutoSize = true;
-            this.utf32TextSettingsLabel.Location = new System.Drawing.Point(254, 233);
-            this.utf32TextSettingsLabel.Name = "utf32TextSettingsLabel";
-            this.utf32TextSettingsLabel.Size = new System.Drawing.Size(43, 13);
-            this.utf32TextSettingsLabel.TabIndex = 52;
-            this.utf32TextSettingsLabel.Text = "UTF32:";
+            this.projectSettingTabPage.Controls.Add(this.label1);
+            this.projectSettingTabPage.Controls.Add(this.compressZipCheckBox);
+            this.projectSettingTabPage.Location = new System.Drawing.Point(4, 25);
+            this.projectSettingTabPage.Name = "projectSettingTabPage";
+            this.projectSettingTabPage.Size = new System.Drawing.Size(741, 408);
+            this.projectSettingTabPage.TabIndex = 3;
+            this.projectSettingTabPage.Text = "Project Settings";
+            this.projectSettingTabPage.UseVisualStyleBackColor = true;
             // 
-            // utf32TextTypeTextBox
+            // compressZipCheckBox
             // 
-            this.utf32TextTypeTextBox.Location = new System.Drawing.Point(346, 230);
-            this.utf32TextTypeTextBox.Name = "utf32TextTypeTextBox";
-            this.utf32TextTypeTextBox.Size = new System.Drawing.Size(120, 20);
-            this.utf32TextTypeTextBox.TabIndex = 51;
+            this.compressZipCheckBox.AutoSize = true;
+            this.compressZipCheckBox.Location = new System.Drawing.Point(25, 38);
+            this.compressZipCheckBox.Name = "compressZipCheckBox";
+            this.compressZipCheckBox.Size = new System.Drawing.Size(132, 20);
+            this.compressZipCheckBox.TabIndex = 0;
+            this.compressZipCheckBox.Text = "Compress as ZIP";
+            this.compressZipCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(4, 10);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(301, 16);
+            this.label1.TabIndex = 45;
+            this.label1.Text = "These settings only affect the project when saved:";
             // 
             // SettingsForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(586, 427);
+            this.ClientSize = new System.Drawing.Size(781, 526);
             this.Controls.Add(this.bannerBox);
             this.Controls.Add(this.settingsTabControl);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "SettingsForm";
@@ -1141,6 +1283,8 @@ namespace ReClassNET.Forms
             this.typeDefinitionsSettingsTabPage.ResumeLayout(false);
             this.typeDefinitionsSettingsTabPage.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.bannerBox)).EndInit();
+            this.projectSettingTabPage.ResumeLayout(false);
+            this.projectSettingTabPage.PerformLayout();
             this.ResumeLayout(false);
 
 		}
@@ -1247,5 +1391,8 @@ namespace ReClassNET.Forms
 		private System.Windows.Forms.TextBox nintTypeTextBox;
 		private System.Windows.Forms.Label utf32TextSettingsLabel;
 		private System.Windows.Forms.TextBox utf32TextTypeTextBox;
-	}
+        private System.Windows.Forms.TabPage projectSettingTabPage;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.CheckBox compressZipCheckBox;
+    }
 }

--- a/ReClass.NET/Forms/SettingsForm.cs
+++ b/ReClass.NET/Forms/SettingsForm.cs
@@ -40,6 +40,7 @@ namespace ReClassNET.Forms
 			SetGeneralBindings();
 			SetColorBindings();
 			SetTypeDefinitionBindings();
+			SetProjectSettingsBindings();
 
 			if (NativeMethods.IsUnix())
 			{
@@ -152,6 +153,11 @@ namespace ReClassNET.Forms
 			SetBinding(utf16TextTypeTextBox, nameof(TextBox.Text), typeMapping, nameof(CppTypeMapping.TypeUtf16Text));
 			SetBinding(utf32TextTypeTextBox, nameof(TextBox.Text), typeMapping, nameof(CppTypeMapping.TypeUtf32Text));
 			SetBinding(functionPtrTypeTextBox, nameof(TextBox.Text), typeMapping, nameof(CppTypeMapping.TypeFunctionPtr));
+		}
+
+		private void SetProjectSettingsBindings()
+		{
+			SetBinding(compressZipCheckBox, nameof(CheckBox.Checked), settings, nameof(Settings.CompressAsZip));
 		}
 	}
 }

--- a/ReClass.NET/ReClass.NET.csproj
+++ b/ReClass.NET/ReClass.NET.csproj
@@ -151,9 +151,13 @@
     <Compile Include="Core\IInternalCoreFunctions.cs" />
     <Compile Include="Core\InternalCoreFunctions.cs" />
     <Compile Include="Core\NativeCoreWrapper.cs" />
+    <Compile Include="DataExchange\ReClass\ReClassDataFile.cs" />
     <Compile Include="DataExchange\ReClass\ReClassClipboard.cs" />
+    <Compile Include="DataExchange\ReClass\ReClassDataFile.Constants.cs" />
     <Compile Include="DataExchange\ReClass\ReClassNetFile.Constants.cs" />
+    <Compile Include="DataExchange\ReClass\ReClassDataFile.Read.cs" />
     <Compile Include="DataExchange\ReClass\ReClassNetFile.Read.cs" />
+    <Compile Include="DataExchange\ReClass\ReClassDataFile.Write.cs" />
     <Compile Include="DataExchange\ReClass\ReClassNetFile.Write.cs" />
     <Compile Include="DataExchange\ReClass\Legacy\BaseClassArrayNode.cs" />
     <Compile Include="DataExchange\ReClass\Legacy\ClassInstanceArrayNode.cs" />

--- a/ReClass.NET/Settings.cs
+++ b/ReClass.NET/Settings.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 using System.Text;
 using ReClassNET.Util;
 
@@ -77,5 +77,9 @@ namespace ReClassNET
 		public CustomDataMap CustomData { get; } = new CustomDataMap();
 
 		public Settings Clone() => MemberwiseClone() as Settings;
+
+		// Project Settings
+
+		public bool CompressAsZip { get; set; } = true;
 	}
 }


### PR DESCRIPTION
I know someone already opened a PR for this feature, however I decided to try implementing it a little differently on my fork. Instead of modifying the ReClassNetFile class(es), I decided to create a new one called ReClassDataFile. Enabling/Disabling the "Compress as ZIP" under a new "Project Settings" tab will enable/disable the use of ReClassDataFile over ReClassNetFile. The benefit of using a new class to implement the feature is that it continues to follow the current code format/style, whereas just modifying the ReClassNetFile class directly could encourage code to become a little 'messy'.

There are some more things I should probably fix/change to make this a better suited PR for merging, such as:
- Just putting "Compress as ZIP" under "General" instead of "Project Settings". I think it would be better to have a general project-specific settings tab, but that may not be the case.
- Opening a rcnet or xml file should adjust the setting accordingly.